### PR TITLE
[Pipelines support] Apply fix for SNAT warnings in JS bots

### DIFF
--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/index.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/index.js
@@ -4,6 +4,8 @@
 // index.js is used to setup and configure your bot
 
 // Import required packages
+const http = require('http');
+const https = require('https');
 const path = require('path');
 const restify = require('restify');
 
@@ -23,12 +25,30 @@ const { SkillConversationIdFactory } = require('./skillConversationIdFactory');
 const { allowedSkillsClaimsValidator } = require('./authentication/allowedSkillsClaimsValidator');
 const { SetupDialog } = require('./dialogs/setupDialog');
 
+const maxTotalSockets = (preallocatedSnatPorts, procCount = 1, weight = 0.5, overcommit = 1.1) =>
+  Math.min(
+    Math.floor((preallocatedSnatPorts / procCount) * weight * overcommit),
+    preallocatedSnatPorts
+  );
+
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({
   appId: process.env.MicrosoftAppId,
   appPassword: process.env.MicrosoftAppPassword,
-  authConfig: new AuthenticationConfiguration([], allowedSkillsClaimsValidator)
+  authConfig: new AuthenticationConfiguration([], allowedSkillsClaimsValidator),
+  clientOptions: {
+    agentSettings: {
+      http: new http.Agent({
+        keepAlive: true,
+        maxTotalSockets: maxTotalSockets(1024, 4, 0.3),
+      }),
+      https: new https.Agent({
+        keepAlive: true,
+        maxTotalSockets: maxTotalSockets(1024, 4, 0.7),
+      }),
+    },
+  },
 });
 
 // Catch-all for errors.

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/index.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/index.js
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 const dotenv = require('dotenv');
+const http = require('http');
+const https = require('https');
 const path = require('path');
 const restify = require('restify');
 
@@ -29,12 +31,30 @@ server.listen(process.env.port || process.env.PORT || 36400, () => {
 // Expose the manifest
 server.get('/manifests/*', restify.plugins.serveStatic({ directory: './manifests', appendRequestPath: false }));
 
+const maxTotalSockets = (preallocatedSnatPorts, procCount = 1, weight = 0.5, overcommit = 1.1) =>
+  Math.min(
+    Math.floor((preallocatedSnatPorts / procCount) * weight * overcommit),
+    preallocatedSnatPorts
+  );
+
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about how bots work.
 const adapter = new BotFrameworkAdapter({
   appId: process.env.MicrosoftAppId,
   appPassword: process.env.MicrosoftAppPassword,
-  authConfig: new AuthenticationConfiguration([], allowedCallersClaimsValidator)
+  authConfig: new AuthenticationConfiguration([], allowedCallersClaimsValidator),
+  clientOptions: {
+    agentSettings: {
+      http: new http.Agent({
+        keepAlive: true,
+        maxTotalSockets: maxTotalSockets(1024, 4, 0.3),
+      }),
+      https: new https.Agent({
+        keepAlive: true,
+        maxTotalSockets: maxTotalSockets(1024, 4, 0.7),
+      }),
+    },
+  },
 });
 
 // Catch-all for errors.


### PR DESCRIPTION
# Description

This PR adds configuration options to the JS bot's adapters to limit the total sockets.

We tested the changes in the pipelines with 20 runs we didn't see any ConnectionTimeout or the error message associated with it (connect ETIMEDOUT).