### PR TITLE
[#423] Remove duplicated EOC in WaterfallSkillBotPython to fix 404 errors

### DIFF
--- a/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/card_dialog.py
+++ b/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/card_dialog.py
@@ -19,9 +19,6 @@ from botbuilder.dialogs.prompts import (
     PromptValidatorContext,
 )
 from botbuilder.schema import (
-    Activity,
-    ActivityTypes,
-    EndOfConversationCodes,
     InputHints,
     HeroCard,
     CardAction,
@@ -219,13 +216,6 @@ class CardDialog(ComponentDialog):
                     )
 
                 elif card_type == CardOptions.END:
-                    # End the dialog so the host gets an EoC
-                    await step_context.context.send_activity(
-                        Activity(
-                            type=ActivityTypes.end_of_conversation,
-                            code=EndOfConversationCodes.completed_successfully,
-                        )
-                    )
                     return DialogTurnResult(DialogTurnStatus.Complete)
 
             else:

--- a/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/delete/delete_dialog.py
+++ b/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/delete/delete_dialog.py
@@ -10,7 +10,6 @@ from botbuilder.dialogs import (
     DialogTurnResult,
     DialogTurnStatus,
 )
-from botbuilder.schema import Activity, ActivityTypes, EndOfConversationCodes
 from botframework.connector import Channels
 
 
@@ -41,12 +40,5 @@ class DeleteDialog(ComponentDialog):
                     f"Delete is not supported in the {channel} channel."
                 )
             )
-
-        await step_context.context.send_activity(
-            Activity(
-                type=ActivityTypes.end_of_conversation,
-                code=EndOfConversationCodes.completed_successfully,
-            )
-        )
 
         return DialogTurnResult(DialogTurnStatus.Complete)

--- a/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/file_upload/file_upload_dialog.py
+++ b/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/file_upload/file_upload_dialog.py
@@ -15,12 +15,7 @@ from botbuilder.dialogs import (
     ConfirmPrompt,
 )
 from botbuilder.dialogs.prompts import PromptOptions, AttachmentPrompt
-from botbuilder.schema import (
-    InputHints,
-    Activity,
-    ActivityTypes,
-    EndOfConversationCodes,
-)
+from botbuilder.schema import InputHints
 
 
 class FileUploadDialog(ComponentDialog):
@@ -88,10 +83,4 @@ class FileUploadDialog(ComponentDialog):
         if try_another:
             return await step_context.replace_dialog(self.initial_dialog_id)
 
-        await step_context.context.send_activity(
-            Activity(
-                type=ActivityTypes.end_of_conversation,
-                code=EndOfConversationCodes.completed_successfully,
-            )
-        )
         return DialogTurnResult(DialogTurnStatus.Complete)

--- a/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/message_with_attachment/message_with_attachment_dialog.py
+++ b/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/message_with_attachment/message_with_attachment_dialog.py
@@ -17,10 +17,7 @@ from botbuilder.dialogs import (
 from botbuilder.dialogs.prompts import PromptOptions
 from botbuilder.schema import (
     Attachment,
-    InputHints,
-    Activity,
-    ActivityTypes,
-    EndOfConversationCodes,
+    InputHints
 )
 
 from config import DefaultConfig
@@ -106,12 +103,6 @@ class MessageWithAttachmentDialog(ComponentDialog):
         if try_another:
             return await step_context.replace_dialog(self.initial_dialog_id)
 
-        await step_context.context.send_activity(
-            Activity(
-                type=ActivityTypes.end_of_conversation,
-                code=EndOfConversationCodes.completed_successfully,
-            )
-        )
         return DialogTurnResult(DialogTurnStatus.Complete)
 
     async def get_inline_attachment(self):

--- a/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/proactive/wait_for_proactive_dialog.py
+++ b/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/proactive/wait_for_proactive_dialog.py
@@ -5,10 +5,8 @@ from typing import Dict
 from botbuilder.core import MessageFactory, BotAdapter, TurnContext
 from botbuilder.dialogs import Dialog, DialogContext, DialogTurnResult, DialogTurnStatus
 from botbuilder.schema import (
-    Activity,
     ActivityTypes,
-    ActivityEventNames,
-    EndOfConversationCodes,
+    ActivityEventNames
 )
 from config import DefaultConfig
 from .continuation_parameters import ContinuationParameters
@@ -57,12 +55,6 @@ class WaitForProactiveDialog(Dialog):
             )
 
             # End the dialog so the host gets an EoC
-            await dialog_context.context.send_activity(
-                Activity(
-                    type=ActivityTypes.end_of_conversation,
-                    code=EndOfConversationCodes.completed_successfully,
-                )
-            )
             return DialogTurnResult(DialogTurnStatus.Complete)
 
         # Keep waiting for a call to the ProactiveController.

--- a/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/update/update_dialog.py
+++ b/Bots/Python/Skills/CodeFirst/WaterfallSkillBot/dialogs/update/update_dialog.py
@@ -13,7 +13,6 @@ from botbuilder.dialogs import (
     DialogTurnStatus,
     PromptOptions,
 )
-from botbuilder.schema import Activity, ActivityTypes, EndOfConversationCodes
 from botframework.connector import Channels
 
 
@@ -67,12 +66,6 @@ class UpdateDialog(ComponentDialog):
                 )
             )
 
-            await step_context.context.send_activity(
-                Activity(
-                    type=ActivityTypes.end_of_conversation,
-                    code=EndOfConversationCodes.completed_successfully,
-                )
-            )
             return DialogTurnResult(DialogTurnStatus.Complete)
 
         # Ask if we want to update the activity again.
@@ -94,10 +87,4 @@ class UpdateDialog(ComponentDialog):
 
         self._update_tracker.pop(step_context.context.activity.conversation.id)
 
-        await step_context.context.send_activity(
-            Activity(
-                type=ActivityTypes.end_of_conversation,
-                code=EndOfConversationCodes.completed_successfully,
-            )
-        )
         return DialogTurnResult(DialogTurnStatus.Complete)


### PR DESCRIPTION
Fixes # 423

## Description
This PR removes the duplicated _EndOfConversation_ activity that the WaterfallSkillBotPython was sending to finish ìts dialogs.
This extra activity is not necessary as the EOC is sent by the [DialogExtension](https://github.com/microsoft/botbuilder-python/blob/main/libraries/botbuilder-dialogs/botbuilder/dialogs/dialog_extensions.py#L66) class when `DialogTurnStatus` is set to `Complete`.

### Detailed changes
Updated the following classes to remove duplicated EOC activity and the unnecessary related imports: 
- card_dialog
- delete_dialog
- file_upload_dialog
- message_with_attachment_dialog
- wait_for_proactive_dialog
- update_dialog

## Testing
This image shows the tests passing after the changes.
[image]