### PR TITLE
[Test Scenarios pipeline] Fix error in configuration step

### DIFF
--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -173,9 +173,9 @@ steps:
             $bot = $_;
 
             if ($groups.Value -contains $bot.resourceGroup) {
-              $exists = -not (az resource wait --exists --resource-group $bot.resourceGroup --name $bot.resourceBotName --resource-type Microsoft.Web/sites --interval 1 --timeout 6);
+              $enabled = (az webapp show --name $bot.resourceBotName --resource-group $bot.resourceGroup 2>$null | ConvertFrom-Json).enabled;
 
-              if ($exists) {
+              if ($enabled) {
                 Write-Host $(AddTimeStamp -text "$($bot.key): Resource '$($bot.resourceBotName)' found.");
                 return $bot;
               }


### PR DESCRIPTION
## Description

After the pipeline updated the Azure CLI version to [2.24.0](https://github.com/MicrosoftDocs/azure-docs-cli/blob/master/docs-ref-conceptual/release-notes-azure-cli.md#may-25-2021), the configuration step of the _Run Test Scenarios_ pipeline started to fail.
This PR replaces the command [az resource wait --exists](https://docs.microsoft.com/en-us/cli/azure/resource?view=azure-cli-latest#az_resource_wait) used to check the existence of the web apps with the command [az webapp show](https://docs.microsoft.com/en-us/cli/azure/webapp?view=azure-cli-latest#az_webapp_show).

### Detailed Changes
- Updated **_configureConsumers_** script to use `az webapp show` and check if the webapp is enabled before configuring the host and skills bots. 

## Testing
These images show the configuration step before and after applying the changes.
![image](https://user-images.githubusercontent.com/44245136/120232898-e87f3d80-c22a-11eb-8a1c-df037e801f1b.png)

