### PR TITLE
[#414] Add Assert.NotNull to SignIn Attachments to prevent System.NullReferenceException

### DIFF
--- a/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
+++ b/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
@@ -93,13 +93,13 @@ namespace SkillFunctionalTests.SignIn
             await runner.AssertReplyAsync(activity =>
             {
                 Assert.Equal(ActivityTypes.Message, activity.Type);
-                Assert.NotNull(activity.Attachments);
-                Assert.True(activity.Attachments.Count > 0);
+                Assert.True(activity.Attachments != null, "Activity.Attachments property is null.");
+                Assert.True(activity.Attachments.Count > 0, "Activity.Attachments property is empty.");
 
                 var card = JsonConvert.DeserializeObject<SigninCard>(JsonConvert.SerializeObject(activity.Attachments.FirstOrDefault().Content));
                 signInUrl = card.Buttons[0].Value?.ToString();
 
-                Assert.False(string.IsNullOrEmpty(signInUrl));
+                Assert.False(string.IsNullOrEmpty(signInUrl), "SignIn url is null or empty.");
             });
 
             // Execute the SignIn.

--- a/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
+++ b/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
@@ -93,6 +93,7 @@ namespace SkillFunctionalTests.SignIn
             await runner.AssertReplyAsync(activity =>
             {
                 Assert.Equal(ActivityTypes.Message, activity.Type);
+                Assert.NotNull(activity.Attachments);
                 Assert.True(activity.Attachments.Count > 0);
 
                 var card = JsonConvert.DeserializeObject<SigninCard>(JsonConvert.SerializeObject(activity.Attachments.FirstOrDefault().Content));


### PR DESCRIPTION
Addresses # 414

## Description
This PR adds assertion to the SignIn tests to prevent the thrown `System.NullReferenceException` error when the `Attachments` property comes null.

> **Note:** The real error that is causing this issue is the `InvokingSkill`.

## Specific Changes
- Adds `Assert.True(activity.Attachments);` when the `AssertReplyAsync` is executed for SignIn tests.
- Added messages to assertions failures.

## Additional Context
The following image shows the error failure thrown in the Test Scenarios pipeline due to asserting `Activity.Attachments.Count > 0` being Attachments property not defined.
![image](https://user-images.githubusercontent.com/62260472/120801099-1e683e80-c517-11eb-952d-62d266e90874.png)