### PR TITLE
[#414] Fix KeyNotFound error with thread-safe Dictionary object

### DIFF
--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -261,34 +261,36 @@ steps:
           }
 
           $appSettings = Get-Content -Raw $appSettingsPath | ConvertFrom-Json;
-          $appSettings.HostBotClientOptions = @{}
+          $appSettings.HostBotClientOptions = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new();
 
           $AddTimeStampDef = $function:AddTimeStamp.ToString();
 
           $bots | ForEach-Object -Parallel {
             # Gets the Bot DirectLine
             $function:AddTimeStamp = $using:AddTimeStampDef
-            $appSettings = $using:appSettings
+            $options = $using:appSettings.HostBotClientOptions
             $bot = $_;
 
-            Write-Host $(AddTimeStamp -text "$($bot.key): Getting the DirectLine secret.");
             $tries = 3;
             $directLine = "";
 
-            while($tries -gt 0) {
+            while ($tries -gt 0) {
               $directLine = (az bot directline show --name $bot.resourceBotName --resource-group $bot.resourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
+              Write-Host $(AddTimeStamp -text "$($bot.key): Getting the DirectLine secret ($($directLine.Substring(0, 3) + "***")).");
+              
               if (-not [string]::IsNullOrEmpty($directLine)) {
-                $appSettings.HostBotClientOptions[$bot.key] = @{
+                $settings = @{
                   DirectLineSecret = $directLine
                   BotId            = $bot.botName
                 }
+                $options.TryAdd($bot.key, $settings) 1>$null;
                 break;
               }
               $tries--;
             }
           }
 
-          if ($appSettings.HostBotClientOptions.count -ne $bots.length) {
+          if ($appSettings.HostBotClientOptions.Count -ne $bots.Length) {
             Write-Host "##vso[task.logissue type=error]Some host bots' DirectLine secrets couldn't be retrieved from Azure."
             $config = $appSettings.HostBotClientOptions | Out-String
             Write-Host "##vso[task.logissue type=error]$config"
@@ -298,8 +300,13 @@ steps:
           $appSettings | ConvertTo-Json | Set-Content $appsettingsPath;
 
           Write-Host $(AddTimeStamp -text "Test Project AppSettings saved:");
-          $appSettings.HostBotClientOptions;
-          Write-Host ""; # Separator
+          $appSettings.HostBotClientOptions.GetEnumerator() | ForEach-Object { 
+            return [PSCustomObject]@{ 
+              Key  = $_.Key
+              BotId = $_.Value.BotId
+              DirectLineSecret = $_.Value.DirectLineSecret.Substring(0, 3) + "***"
+            } 
+          } | Format-Table -AutoSize
         }
 
         function ConfigureConsumers {


### PR DESCRIPTION
Addresses # 414

## Description
This PR fixes an issue when the Test Scenarios configuration script or the tests being executed fail with `KeyNotFound` due to not finding the right bot configuration in the FunctionalTests `appsettings.json` file.
The issue was caused by performing updates to an object outside the `ForEach-Object -Parallel` that was not thread-safe (`System.Collections.Generic.Dictionary`), instead a proper approach to manage thread-safe objects is to use `System.Collections.Concurrent.ConcurrentDictionary`, ([thread-safe sample](https://docs.microsoft.com/ja-jp/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7#example-14--using-thread-safe-variable-references))

## Specific Changes
Templates:
  - Updated HostBotClientOptions to be a `System.Collections.Concurrent.ConcurrentDictionary` instance instead of a `System.Collections.Generic.Dictionary` to perform thread-safe operations over the object.
  - Improved output logging when saving the information to the `appsettings.json` file.

## Testing
The following images show the pipeline passing and the improved configuration output.
![image](https://user-images.githubusercontent.com/62260472/123312183-5e12bc80-d4fe-11eb-83c8-92e683c40354.png)
![image](https://user-images.githubusercontent.com/62260472/123310933-fc9e1e00-d4fc-11eb-9298-af649642fc06.png)
