### PR TITLE
[#438] Several deployments fail with "Run From Package Initialization failed."

### DIFF
--- a/build/templates/template-bot-resources.json
+++ b/build/templates/template-bot-resources.json
@@ -55,7 +55,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2020-09-01",
+      "apiVersion": "2018-02-01",
       "name": "[parameters('botName')]",
       "location": "[parameters('botLocation')]",
       "kind": "app",
@@ -78,6 +78,10 @@
         "hyperV": false,
         "siteConfig": {
           "appSettings": [
+            {
+              "name": "WEBSITE_RUN_FROM_PACKAGE",
+              "value": "1"
+            },
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
               "value": "10.14.1"
@@ -223,8 +227,8 @@
     {
       "condition": "[not(empty(parameters('virtualNetworkName')))]",
       "name": "[concat(parameters('botName'), '/virtualNetwork')]",
-      "type": "Microsoft.Web/sites/config",
-      "apiVersion": "2018-02-01",
+      "type": "Microsoft.Web/sites/virtualNetworkConnections",
+      "apiVersion": "2018-11-01",
       "location": "[parameters('botLocation')]",
       "dependsOn": [
           "[resourceId('Microsoft.Web/sites', parameters('botName'))]"

--- a/build/templates/template-bot-resources.json
+++ b/build/templates/template-bot-resources.json
@@ -55,7 +55,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2018-02-01",
+      "apiVersion": "2020-09-01",
       "name": "[parameters('botName')]",
       "location": "[parameters('botLocation')]",
       "kind": "app",
@@ -77,7 +77,7 @@
         "reserved": true,
         "hyperV": false,
         "siteConfig": {
-          "appSettings": [            
+          "appSettings": [
             {
               "name": "WEBSITE_RUN_FROM_PACKAGE",
               "value": "1"

--- a/build/templates/template-python-bot-resources.json
+++ b/build/templates/template-python-bot-resources.json
@@ -52,7 +52,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2018-02-01",
+      "apiVersion": "2020-09-01",
       "name": "[parameters('botName')]",
       "location": "[parameters('botLocation')]",
       "kind": "app,linux",

--- a/build/templates/template-python-bot-resources.json
+++ b/build/templates/template-python-bot-resources.json
@@ -52,7 +52,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2020-09-01",
+      "apiVersion": "2018-02-01",
       "name": "[parameters('botName')]",
       "location": "[parameters('botLocation')]",
       "kind": "app,linux",
@@ -209,8 +209,8 @@
     {
       "condition": "[not(empty(parameters('virtualNetworkName')))]",
       "name": "[concat(parameters('botName'), '/virtualNetwork')]",
-      "type": "Microsoft.Web/sites/config",
-      "apiVersion": "2018-02-01",
+      "type": "Microsoft.Web/sites/virtualNetworkConnections",
+      "apiVersion": "2018-11-01",
       "location": "[parameters('botLocation')]",
       "dependsOn": [
           "[resourceId('Microsoft.Web/sites', parameters('botName'))]"

--- a/build/yaml/deployBotResources/common/deleteResources.yml
+++ b/build/yaml/deployBotResources/common/deleteResources.yml
@@ -29,6 +29,7 @@ steps:
             Write-Host "Starting resource cleanup..."
 
             Write-Host ("Deleting '" + "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" + "'...")
+            az webapp vnet-integration remove --name "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --resource-group ${{ parameters.resourceGroup }}
             az webapp delete --name "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --resource-group ${{ parameters.resourceGroup }} --keep-empty-plan
             az bot delete --name "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --resource-group ${{ parameters.resourceGroup }}
 

--- a/build/yaml/deployBotResources/common/deleteResources.yml
+++ b/build/yaml/deployBotResources/common/deleteResources.yml
@@ -29,7 +29,6 @@ steps:
             Write-Host "Starting resource cleanup..."
 
             Write-Host ("Deleting '" + "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" + "'...")
-            az webapp vnet-integration remove --name "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --resource-group ${{ parameters.resourceGroup }}
             az webapp delete --name "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --resource-group ${{ parameters.resourceGroup }} --keep-empty-plan
             az bot delete --name "${{ parameters.resourceName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --resource-group ${{ parameters.resourceGroup }}
 

--- a/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -283,7 +283,7 @@ stages:
               appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
               resourceGroupName: '${{ parameters.resourceGroup }}'
               package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ parameters.buildFolder }}/${{ bot.name }}/${{ bot.name }}.zip'
-              deploymentMethod: zipDeploy
+              deploymentMethod: runFromPackage
 
           # Configure OAuth
           - ${{ if eq(bot.type, 'Skill') }}:

--- a/build/yaml/deployBotResources/js/deploy.yml
+++ b/build/yaml/deployBotResources/js/deploy.yml
@@ -205,7 +205,7 @@ stages:
               appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
               resourceGroupName: '${{ parameters.resourceGroup }}'
               package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}.zip'
-              deploymentMethod: zipDeploy
+              deploymentMethod: runFromPackage
 
           # Configure OAuth
           - ${{ if eq(bot.type, 'Skill') }}:


### PR DESCRIPTION
Fixes # 438

## Description
This PR fixes an issue where the `AzureWebApp@1` task fails with a Kudu Zip Deployment error (`Failed to deploy web package to App Service.`).
This issue was caused due to two set of configuration steps that made the App Service to restart and fail when processing the uploaded Zip:
1. There was missing the `WEBSITE_RUN_FROM_PACKAGE` setting from the ARM Template.
    - When the variable is not set, the `AzureWebApp@1/runFromPackage` method will update the variable showing the `Updated App Service Application settings and Kudu Application settings` message, otherwise will show `App Service Application settings are already present.` avoiding the App Service restart.
 
2. Using `Microsoft.Web/sites/config` to configure the Virtual Network Subnet was causing the restart of the App Service.
    - Changing the resource type to configure the Subnet in the App Service with `Microsoft.Web/sites/virtualNetworkConnections` solved the issue.

## Specific Changes
- Added `WEBSITE_RUN_FROM_PACKAGE` explicitly for DotNet and JS bots.
- Replaced `Microsoft.Web/sites/config` with `Microsoft.Web/sites/virtualNetworkConnections`.
- Replaced `AzureWebApp@1` `zipDeploy` with `runFromPackage`.

## Testing
The following image shows the list of Deploy pipelines runs and the Kudu Zip deploy error.
![image](https://user-images.githubusercontent.com/62260472/123844322-42862800-d8e9-11eb-825e-1edc529ce0a6.png)
![image](https://user-images.githubusercontent.com/62260472/123844398-5b8ed900-d8e9-11eb-9ac5-428939e5a37c.png)