### PR TITLE
[#414] Add thinking time in test runner to reduce conversation restarted errors

### DIFF
--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -295,6 +295,9 @@ namespace TranscriptTestRunner
                             Text = scriptActivity.Text
                         };
 
+                        // Thinking time
+                        await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
+
                         await SendActivityAsync(sendActivity, cancellationToken).ConfigureAwait(false);
                         break;
 


### PR DESCRIPTION
Addresses # 414

# Summary

This PRs adds a _thinking time_ in the test runner before sending activities to the bot to give it time to properly save the state, reducing the occurrences of the _conversation restarted_ issue.

## Specific changes

Added a delay in the `TestRunner.cs` of 500ms before sending the activity messages to the bot with the user role.

## Additional details

By adding this delay the _test scenarios_ pipelines increase their time from 10-20 minutes to 20-30 minutes.
Because of this, we will consider this change as temporary to allow the tests to pass while we look for better approaches that don't impact as much in the total time.

## Testing

To test the change we run a total of 35 _test scenarios_ pipelines, where no occurrence of the _conversation restarted_ issue showed up.
Below are some examples.
![image](https://user-images.githubusercontent.com/38112957/124017894-a0843f80-d9bd-11eb-849e-a22cf6eadc25.png)
