### PR TITLE
[Cleanup Resources Pipeline] Add delete stage for Virtual Network.

### DIFF
--- a/build/yaml/cleanupResources/cleanupResources.yml
+++ b/build/yaml/cleanupResources/cleanupResources.yml
@@ -140,9 +140,9 @@ stages:
 - stage: "Delete_Virtual_Network"
   displayName: "Delete Virtual Network"
   dependsOn:
-    - Delete_DotNet_Resource_Group
-    - Delete_JS_Resource_Group
-    - Delete_Python_Resource_Group
+    - Delete_App_Service_Plan_DotNet
+    - Delete_App_Service_Plan_JS
+    - Delete_App_Service_Plan_Python
   jobs:
     - job: "Delete"
       displayName: "Delete steps"
@@ -278,16 +278,13 @@ stages:
 
 - stage: "Delete_Resource_Group_Windows"
   displayName: "Delete Resource Group (Windows)"
-  dependsOn: 
-    - Delete_DotNet_Resource_Group
-    - Delete_JS_Resource_Group
-    - Delete_App_Service_Plan_DotNet
-    - Delete_App_Service_Plan_JS
+  dependsOn:
+    - Delete_Virtual_Network
+    - Delete_App_Registrations
+    - Delete_Key_Vault
     - Delete_App_Insights
     - Delete_CosmosDB
     - Delete_Container_Registry
-    - Delete_App_Registrations
-    - Delete_Key_Vault
   jobs:
     - job: "Delete"
       displayName: "Delete steps"

--- a/build/yaml/cleanupResources/cleanupResources.yml
+++ b/build/yaml/cleanupResources/cleanupResources.yml
@@ -18,12 +18,12 @@ variables:
   InternalAppServicePlanDotNetName: "bffnbotsappservicedotnet$($env:RESOURCESUFFIX)"
   InternalAppServicePlanJSName: "bffnbotsappservicejs$($env:RESOURCESUFFIX)"
   InternalAppServicePlanPythonName: "bffnbotsappservicepython$($env:RESOURCESUFFIX)"
-  InternalVirtualNetworkName: "bffnvirtualnetwork$($env:RESOURCESUFFIX)"
   InternalCosmosDBName: "bffnbotstatedb$($env:RESOURCESUFFIX)"
   InternalContainerRegistryName: "bffncontainerregistry$($env:RESOURCESUFFIX)"
   InternalKeyVaultName: "bffnbotkeyvault$($env:RESOURCESUFFIX)"
   InternalBotResourceGroupName: $[coalesce(variables['DEPLOYRESOURCEGROUP'], 'bffnbots')]
   InternalSharedResourceGroupName: $[coalesce(variables['SHAREDRESOURCEGROUP'], 'bffnshared')]
+  InternalVirtualNetworkName: "bffnvirtualnetwork$($env:RESOURCESUFFIX)"
 
 pool:
   vmImage: "windows-2019"

--- a/build/yaml/cleanupResources/cleanupResources.yml
+++ b/build/yaml/cleanupResources/cleanupResources.yml
@@ -18,6 +18,7 @@ variables:
   InternalAppServicePlanDotNetName: "bffnbotsappservicedotnet$($env:RESOURCESUFFIX)"
   InternalAppServicePlanJSName: "bffnbotsappservicejs$($env:RESOURCESUFFIX)"
   InternalAppServicePlanPythonName: "bffnbotsappservicepython$($env:RESOURCESUFFIX)"
+  InternalVirtualNetworkName: "bffnvirtualnetwork$($env:RESOURCESUFFIX)"
   InternalCosmosDBName: "bffnbotstatedb$($env:RESOURCESUFFIX)"
   InternalKeyVaultName: "bffnbotkeyvault$($env:RESOURCESUFFIX)"
   InternalBotResourceGroupName: $[coalesce(variables['DEPLOYRESOURCEGROUP'], 'bffnbots')]
@@ -133,6 +134,32 @@ stages:
                 az appservice plan delete --name "$(INTERNALAPPSERVICEPLANPYTHONNAME)" --resource-group "$(INTERNALSHAREDRESOURCEGROUPNAME)-linux" --yes
               } else {
                 Write-Host "No pre-existing $(INTERNALAPPSERVICEPLANPYTHONNAME) resource found."
+              }
+
+- stage: "Delete_Virtual_Network"
+  displayName: "Delete Virtual Network"
+  dependsOn:
+    - Delete_DotNet_Resource_Group
+    - Delete_JS_Resource_Group
+    - Delete_Python_Resource_Group
+  jobs:
+    - job: "Delete"
+      displayName: "Delete steps"
+      steps:
+        - task: AzureCLI@2
+          displayName: "Delete Virtual Network"
+          inputs:
+            azureSubscription: $(AZURESUBSCRIPTION)
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              Write-Host "Looking for $(INTERNALVIRTUALNETWORKNAME)..."
+              $exists = az network vnet show --name "$(INTERNALVIRTUALNETWORKNAME)" --resource-group "$(INTERNALSHAREDRESOURCEGROUPNAME)"
+              if ($exists) {
+                Write-Host "Deleting $(INTERNALVIRTUALNETWORKNAME)..."
+                az network vnet delete --name "$(INTERNALVIRTUALNETWORKNAME)" --resource-group "$(INTERNALSHAREDRESOURCEGROUPNAME)"
+              } else {
+                Write-Host "No pre-existing $(INTERNALVIRTUALNETWORKNAME) resource found."
               }
 
 - stage: "Delete_App_Registrations"


### PR DESCRIPTION
Addresses # XXX

## Description

This PRs adds a `delete stage` for the Virtual Network to run over the `Cleanup Resources` pipeline.

## Specific changes

Added a stage in the `cleanupResources.yml` file validating the vnet existence and deleting it if any.
Also, the `dependsOn` property for the `Delete_Resource_Group_Windows` stage was modified to only depends on the following stages:
-  Delete_Virtual_Network
-  Delete_App_Registrations
-  Delete_Key_Vault
-  Delete_App_Insights
-  Delete_CosmosDB
-  Delete_Container_Registry

This change was made to fix the stages visual arrangement within the pipeline view as you can see in the following image
![image](https://user-images.githubusercontent.com/54330145/124292201-b152c380-db2b-11eb-9090-12c1914dcd88.png)

## Testing

The virtual network is being deleted successfully having an active connection or not
![image](https://user-images.githubusercontent.com/54330145/124155450-e1875d00-da6c-11eb-9d60-e018a4c2c7b6.png)
