### PR TITLE
[DeployBotResources Pipeline] Update dependency version's LATEST tag

### DIFF
--- a/Docs/pipelines.md
+++ b/Docs/pipelines.md
@@ -90,9 +90,13 @@ You can choose between one of the following options to select the package's feed
   - Pypi
   - Test.Pypi
 
-The version parameters support LATEST (default), STABLE, or a specific version.
+The version parameters support the following options.
 
-Note: Npm and NuGet feeds only support stable versions, fill the corresponding variable with a specific version or set it to `stable`.
+- LATEST: this is the default, and will look for the most recent version.
+- STABLE: will look for the most recent Stable version.
+- custom: you can enter a specific version to look for in the feed, ie `4.14.0.20210416.dev236130`
+
+Note: The artifact feed doesn't contain stable versions for DotNet packages.
 
 ### BotNames
 

--- a/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -170,8 +170,8 @@ stages:
                 project: "${{ bot.project }}"
                 packages:
                   Microsoft.Bot.Builder
-                  Microsoft.Bot.Builder.Azure
                   Microsoft.Bot.Builder.History
+                  Microsoft.Bot.Connector
 
             # Build bot
             - task: MSBuild@1

--- a/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
@@ -19,49 +19,55 @@ steps:
       failOnStderr: true
       script: |
         # Get Source
-        $sourceDotNetv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-dotnet-daily/api/v3/index.json" 
-        $sourceDotNetArtifacts = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
+        $sourceDotNetv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-dotnet-daily/api/v3/index.json"
+        $sourceDotNetArtifacts = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json"
         $sourceDotNetMyGet = "https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json"
+        $sourceDotNetNuGet = "https://api.nuget.org/v3/index.json"
+
         switch -regex ("${{ parameters.registry }}") {
           "^($null|)$" {
             switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceDotNetv3MyGet } 
+              "SkillV3" { $source = $sourceDotNetv3MyGet }
               default { $source = $sourceDotNetArtifacts }
             }
           }
           "Artifacts" { $source = $sourceDotNetArtifacts }
           "MyGet" { 
             switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceDotNetv3MyGet } 
+              "SkillV3" { $source = $sourceDotNetv3MyGet }
               default { $source = $sourceDotNetMyGet }
             }
           }
-          "NuGet" { $source = "" }
+          "NuGet" { $source = $sourceDotNetNuGet }
           default { $source = "${{ parameters.registry }}" }
         }
         Write-Host "Source: $source"
-        
+
         # Get Version Number
+        $tags = ""
         switch -regex ("${{ parameters.version }}") {
-          "^($null||LATEST)$" {
-            if ("${{ parameters.registry }}".ToUpper() -in "NUGET") {
+          "^($null||LATEST||STABLE)$" {
+            if (("${{ parameters.version }}" -in "STABLE") -and ($source -match $sourceDotNetArtifacts)) {
               [Console]::ForegroundColor = "red"
-              [Console]::Error.WriteLine("Preview versions of BotBuilder are not available for this source.")
+              [Console]::Error.WriteLine("Stable versions of BotBuilder DotNet are not available for this source.")
               [Console]::ResetColor()
               exit 1 # Force exit
             }
+            if("${{ parameters.version }}" -notin "STABLE") {
+              $tags = "-PreRelease"
+            }
             if ("${{ parameters.botType }}" -in "Host", "Skill") {
-              $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$source" -PreRelease
-              $versionNumber = $PackageList.Split(" ")[-1]
+              $PackageList = nuget list "Microsoft.Bot.Builder" -Source "$source" "$tags" | Select-String -Pattern "^Microsoft.Bot.Builder "
+              $versionNumber = ($PackageList -split " ")[-1]
             } elseif ("${{ parameters.botType }}" -in "SkillV3") {
-              $versionNumber = ""
+              $PackageList = nuget list "Microsoft.Bot.Builder.History" -Source "$source" "$tags" | Select-String -Pattern "^Microsoft.Bot.Builder.History"
+              $versionNumber = ($PackageList -split " ")[-1]
             }
           }
-          STABLE { $versionNumber = "" }
           default { $versionNumber = "${{ parameters.version }}" }
         }
         Write-Host "Version Number: $versionNumber"
-        
+
         # Set environment variables
         Write-Host "##vso[task.setvariable variable=DependenciesSource]$source"
         Write-Host "##vso[task.setvariable variable=DependenciesVersionNumber]$versionNumber"

--- a/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
@@ -21,11 +21,11 @@ steps:
         # Get Source
         $sourceJSMyGet = "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
         $sourceJSv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-js-daily/npm/"
-        $sourceJSNpm = "https://registry.npmjs.com/" 
+        $sourceJSNpm = "https://registry.npmjs.com/"
         switch -regex ("${{ parameters.registry }}") {
           "^($null|MyGet)$" {
             switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceJSv3MyGet } 
+              "SkillV3" { $source = $sourceJSv3MyGet }
               default { $source = $sourceJSMyGet }
             }
           }
@@ -38,20 +38,17 @@ steps:
         # Get Version Number
         switch -regex ("${{ parameters.version }}") {
           "^($null||LATEST)$" {
-            if ("${{ parameters.registry }}".ToUpper() -in "NPM") {
-              [Console]::ForegroundColor = 'red'
-              [Console]::Error.WriteLine("Preview versions of BotBuilder are not available for this source.")
-              [Console]::ResetColor()
-              exit 1 # Force exit
-            }
-            
-            if ($source -eq $sourceJSMyGet) {
-              $versionNumber = npm show botbuilder@next version | Out-String
+            if ("${{ parameters.botType }}" -in "SkillV3") {
+              if ($source -eq $sourceJSv3MyGet) {
+                $versionNumber = npm show botbuilder@latest version | Out-String
+              } else {
+                $versionNumber = (npm view botbuilder versions | Where-Object {$_ -match "  '3."})[-1].Trim().Replace("'", "").Replace(",", "")
+              }
             } else {
-              $versionNumber = npm show botbuilder@latest version | Out-String
+              $versionNumber = npm show botbuilder@next version | Out-String
             }
           }
-          STABLE { 
+          STABLE {
             if ("${{ parameters.botType }}" -in "Host", "Skill") {
               $PackageList = npm show botbuilder@* version | Out-String;
             }

--- a/build/yaml/deployBotResources/python/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/python/evaluateDependenciesVariables.yml
@@ -31,15 +31,15 @@ steps:
               $source = $sourceArtifacts
               $extraSource = $sourcePypi
             }
-            "Pypi" { 
+            "Pypi" {
               $source = $sourcePypi
-              $extraSource = $sourceArtifacts
+              $extraSource = ""
             }
-            "Test.Pypi" { 
+            "Test.Pypi" {
               $source = $sourceTestPypi
               $extraSource = $sourcePypi
             }
-            default { 
+            default {
               $source = "${{ parameters.registry }}"
               $extraSource = $sourcePypi
             }
@@ -48,28 +48,27 @@ steps:
           # Get Version Number
           switch -regex ("${{ parameters.version }}") {
             "^($null||LATEST)$" {
-              if ("${{ parameters.registry }}".ToUpper() -in "PYPI") {
-                [Console]::ForegroundColor = "red"
-                [Console]::Error.WriteLine("Preview versions of BotBuilder are not available for this source.")
-                [Console]::ResetColor()
-                exit 1 # Force exit
-              }
               $versionNumber = ""
-              $preFag = "--pre"
+              $preFlag = "--pre"
             }
-            STABLE { 
+            STABLE {
               $versionNumber = ""
             }
-            default { 
+            default {
               $versionNumber = "${{ parameters.version }}"
               $condition = "=="
             }
           }
 
-          #Add the $source source at the beginning of requirements
+          # Add the $source source at the beginning of requirements
           $file = "${{ parameters.source }}/requirements.txt"
           $content = @(Get-Content $file)
-          $line = "$preFag --index-url $source --extra-index-url $extraSource".Trim()
+
+          if (-not ([string]::IsNullOrEmpty("$extraSource"))) {
+            $extraSourceTag = "--extra-index-url $extraSource"
+          }
+
+          $line = "$preFlag --index-url $source $extraSourceTag".Trim()
           Set-Content -Path $file -Value $line
           Add-Content -Path $file -Value $content
 


### PR DESCRIPTION
# Description

This PR fixes the behavior for the LATEST tag in the version dependency parameter for the deploy bot resources pipeline.

## Specific changes

- Update  `evaluateDependenciesVariables.yml` for DotNet, JS, and Python to get the most recent version for all feeds when the `LATEST` option is entered in the corresponding version parameter.
- Update packages installed for DotNet v3 Bots, removing `Microsoft.Bot.Builder.Azure` since its versions are not updated and don't correspond with the rest of the packages, and added `Microsoft.Bot.Connector` which does have parity versions with the rest of the BotBuilder v3 packages.
- Update `evaluateDependenciesVariable.yml` for DotNet to include a message error when STABLE versions are asked for the Artifacts feed, since it doesn't contain stable versions.
- Update documentation referred to version options for the version parameter.
- General styling fixes.

## Testing

This is a deploy bot resources pipeline deploying all the bots, all of them using the LATEST tag running with diverse feeds selected.
![image](https://user-images.githubusercontent.com/38112957/117455760-df49cc00-af1d-11eb-8027-eb415f7d4f5a.png)
