### PR TITLE
[#414] Add think time in test runner to reduce conversation restarted errors

### DIFF
--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -28,6 +28,7 @@ namespace TranscriptTestRunner
         private readonly ILogger _logger;
         private readonly int _replyTimeout;
         private readonly TestClientBase _testClient;
+        private readonly double _thinkTime;
         private Stopwatch _stopwatch;
         private string _testScriptPath;
 
@@ -36,11 +37,13 @@ namespace TranscriptTestRunner
         /// </summary>
         /// <param name="client">Test client to use.</param>
         /// <param name="replyTimeout">The timeout for waiting for replies (in seconds). Default is 180.</param>
+        /// <param name="thinkTime">The timeout think time before sending messages to the bot (in miliseconds). Default is 0.</param>
         /// <param name="logger">Optional. Instance of <see cref="ILogger"/> to use.</param>
-        public TestRunner(TestClientBase client, int replyTimeout = 180, ILogger logger = null)
+        public TestRunner(TestClientBase client, int replyTimeout = 180, double thinkTime = 0, ILogger logger = null)
         {
             _testClient = client;
             _replyTimeout = replyTimeout;
+            _thinkTime = thinkTime;
             _logger = logger ?? NullLogger.Instance;
         }
 
@@ -294,6 +297,13 @@ namespace TranscriptTestRunner
                             Type = scriptActivity.Type,
                             Text = scriptActivity.Text
                         };
+
+                        // Think time
+                        if (_thinkTime > 0)
+                        {
+                            _logger.LogInformation($"Running think time of {_thinkTime}ms");
+                            await Task.Delay(TimeSpan.FromMilliseconds(_thinkTime), cancellationToken).ConfigureAwait(false);
+                        }
 
                         await SendActivityAsync(sendActivity, cancellationToken).ConfigureAwait(false);
                         break;

--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -36,10 +36,10 @@ namespace TranscriptTestRunner
         /// Initializes a new instance of the <see cref="TestRunner"/> class.
         /// </summary>
         /// <param name="client">Test client to use.</param>
-        /// <param name="replyTimeout">The timeout for waiting for replies (in seconds). Default is 180.</param>
+        /// <param name="replyTimeout">The timeout for waiting for replies (in miliseconds). Default is 180000.</param>
         /// <param name="thinkTime">The timeout think time before sending messages to the bot (in miliseconds). Default is 0.</param>
         /// <param name="logger">Optional. Instance of <see cref="ILogger"/> to use.</param>
-        public TestRunner(TestClientBase client, int replyTimeout = 180, double thinkTime = 0, ILogger logger = null)
+        public TestRunner(TestClientBase client, int replyTimeout = 180000, int thinkTime = 0, ILogger logger = null)
         {
             _testClient = client;
             _replyTimeout = replyTimeout;
@@ -76,7 +76,7 @@ namespace TranscriptTestRunner
             var testFileName = $"{callerName} - {Path.GetFileNameWithoutExtension(testScriptPath)}";
 
             _logger.LogInformation($"======== Running script: {testScriptPath} ========");
-            _logger.LogInformation($"TestRequestTimeout: {_replyTimeout}s");
+            _logger.LogInformation($"TestRequestTimeout: {_replyTimeout}ms");
             _logger.LogInformation($"ThinkTime: {_thinkTime}ms");
 
             _testScriptPath = testScriptPath;
@@ -140,7 +140,7 @@ namespace TranscriptTestRunner
                 }
 
                 // Check timeout.
-                if (timeoutCheck.ElapsedMilliseconds > _replyTimeout * 1000)
+                if (timeoutCheck.ElapsedMilliseconds > _replyTimeout)
                 {
                     throw new TimeoutException($"Operation timed out while waiting for a response from the bot after {timeoutCheck.ElapsedMilliseconds} milliseconds (current timeout is set to {_replyTimeout * 1000} milliseconds).");
                 }

--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -76,6 +76,8 @@ namespace TranscriptTestRunner
             var testFileName = $"{callerName} - {Path.GetFileNameWithoutExtension(testScriptPath)}";
 
             _logger.LogInformation($"======== Running script: {testScriptPath} ========");
+            _logger.LogInformation($"TestRequestTimeout: {_replyTimeout}s");
+            _logger.LogInformation($"ThinkTime: {_thinkTime}s");
 
             _testScriptPath = testScriptPath;
 
@@ -299,11 +301,7 @@ namespace TranscriptTestRunner
                         };
 
                         // Think time
-                        if (_thinkTime > 0)
-                        {
-                            _logger.LogInformation($"Running think time of {_thinkTime}ms");
-                            await Task.Delay(TimeSpan.FromMilliseconds(_thinkTime), cancellationToken).ConfigureAwait(false);
-                        }
+                        await Task.Delay(TimeSpan.FromMilliseconds(_thinkTime), cancellationToken).ConfigureAwait(false);
 
                         await SendActivityAsync(sendActivity, cancellationToken).ConfigureAwait(false);
                         break;

--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -28,7 +28,7 @@ namespace TranscriptTestRunner
         private readonly ILogger _logger;
         private readonly int _replyTimeout;
         private readonly TestClientBase _testClient;
-        private readonly double _thinkTime;
+        private readonly int _thinkTime;
         private Stopwatch _stopwatch;
         private string _testScriptPath;
 

--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -77,7 +77,7 @@ namespace TranscriptTestRunner
 
             _logger.LogInformation($"======== Running script: {testScriptPath} ========");
             _logger.LogInformation($"TestRequestTimeout: {_replyTimeout}s");
-            _logger.LogInformation($"ThinkTime: {_thinkTime}s");
+            _logger.LogInformation($"ThinkTime: {_thinkTime}ms");
 
             _testScriptPath = testScriptPath;
 

--- a/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
+++ b/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
@@ -21,10 +21,10 @@ namespace TranscriptTestRunner.XUnit
         /// Initializes a new instance of the <see cref="XUnitTestRunner"/> class.
         /// </summary>
         /// <param name="client">Test client to use.</param>
-        /// <param name="replyTimeout">The timeout for waiting for replies (in seconds). Default is 180.</param>
+        /// <param name="replyTimeout">The timeout for waiting for replies (in miliseconds). Default is 180000.</param>
         /// <param name="thinkTime">The timeout think time before sending messages to the bot (in miliseconds). Default is 0.</param>
         /// <param name="logger">Optional. Instance of <see cref="ILogger"/> to use.</param>
-        public XUnitTestRunner(TestClientBase client, int replyTimeout = 180, double thinkTime = 0, ILogger logger = null)
+        public XUnitTestRunner(TestClientBase client, int replyTimeout = 180000, int thinkTime = 0, ILogger logger = null)
             : base(client, replyTimeout, thinkTime, logger)
         {
         }

--- a/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
+++ b/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
@@ -22,9 +22,10 @@ namespace TranscriptTestRunner.XUnit
         /// </summary>
         /// <param name="client">Test client to use.</param>
         /// <param name="replyTimeout">The timeout for waiting for replies (in seconds). Default is 180.</param>
+        /// <param name="thinkTime">The timeout think time before sending messages to the bot (in miliseconds). Default is 0.</param>
         /// <param name="logger">Optional. Instance of <see cref="ILogger"/> to use.</param>
-        public XUnitTestRunner(TestClientBase client, int replyTimeout = 180, ILogger logger = null)
-            : base(client, replyTimeout, logger)
+        public XUnitTestRunner(TestClientBase client, int replyTimeout = 180, double thinkTime = 0, ILogger logger = null)
+            : base(client, replyTimeout, thinkTime, logger)
         {
         }
 

--- a/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
+++ b/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
@@ -105,7 +105,7 @@ namespace SkillFunctionalTests.CardActions
             Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
 
             var options = TestClientOptions[testCase.HostBot];
-            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
 
             var testParams = new Dictionary<string, string>
             {

--- a/Tests/SkillFunctionalTests/FileUpload/FileUploadTests.cs
+++ b/Tests/SkillFunctionalTests/FileUpload/FileUploadTests.cs
@@ -80,7 +80,7 @@ namespace SkillFunctionalTests.FileUpload
             Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
 
             var options = TestClientOptions[testCase.HostBot];
-            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
 
             // Execute the first part of the conversation.
             var testParams = new Dictionary<string, string>

--- a/Tests/SkillFunctionalTests/MessageWithAttachment/MessageWithAttachmentTests.cs
+++ b/Tests/SkillFunctionalTests/MessageWithAttachment/MessageWithAttachmentTests.cs
@@ -77,7 +77,7 @@ namespace SkillFunctionalTests.MessageWithAttachment
             Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
 
             var options = TestClientOptions[testCase.HostBot];
-            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
 
             var testParams = new Dictionary<string, string>
             {

--- a/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
+++ b/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
@@ -81,7 +81,7 @@ namespace SkillFunctionalTests.ProactiveMessages
             Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
 
             var options = TestClientOptions[testCase.HostBot];
-            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
             
             var testParamsStart = new Dictionary<string, string>
             {

--- a/Tests/SkillFunctionalTests/ScriptTestBase.cs
+++ b/Tests/SkillFunctionalTests/ScriptTestBase.cs
@@ -35,7 +35,7 @@ namespace SkillFunctionalTests
 
             TestRequestTimeout = int.Parse(configuration["TestRequestTimeout"]);
             TestClientOptions = configuration.GetSection("HostBotClientOptions").Get<Dictionary<HostBot, DirectLineTestClientOptions>>();
-            ThinkTime = double.Parse(configuration["ThinkTime"]);
+            ThinkTime = int.Parse(configuration["ThinkTime"]);
         }
 
         public Dictionary<HostBot, DirectLineTestClientOptions> TestClientOptions { get; }
@@ -44,6 +44,6 @@ namespace SkillFunctionalTests
 
         public int TestRequestTimeout { get; }
 
-        public double ThinkTime { get; }
+        public int ThinkTime { get; }
     }
 }

--- a/Tests/SkillFunctionalTests/ScriptTestBase.cs
+++ b/Tests/SkillFunctionalTests/ScriptTestBase.cs
@@ -35,6 +35,7 @@ namespace SkillFunctionalTests
 
             TestRequestTimeout = int.Parse(configuration["TestRequestTimeout"]);
             TestClientOptions = configuration.GetSection("HostBotClientOptions").Get<Dictionary<HostBot, DirectLineTestClientOptions>>();
+            ThinkTime = double.Parse(configuration["ThinkTime"]);
         }
 
         public Dictionary<HostBot, DirectLineTestClientOptions> TestClientOptions { get; }
@@ -42,5 +43,7 @@ namespace SkillFunctionalTests
         public ILogger Logger { get; }
 
         public int TestRequestTimeout { get; }
+
+        public double ThinkTime { get; }
     }
 }

--- a/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
+++ b/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
@@ -79,7 +79,7 @@ namespace SkillFunctionalTests.SignIn
             Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
 
             var options = TestClientOptions[testCase.HostBot];
-            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
 
             var testParams = new Dictionary<string, string>
             {

--- a/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
+++ b/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
@@ -90,7 +90,7 @@ namespace SkillFunctionalTests.SingleTurn
 
             var options = TestClientOptions[testCase.HostBot];
 
-            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
 
             var testParams = new Dictionary<string, string>
             {

--- a/Tests/SkillFunctionalTests/appsettings.json
+++ b/Tests/SkillFunctionalTests/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
 
-  "TestRequestTimeout": 180,
+  "TestRequestTimeout": 180000,
   "ThinkTime":  500,
 
   "HostBotClientOptions": {

--- a/Tests/SkillFunctionalTests/appsettings.json
+++ b/Tests/SkillFunctionalTests/appsettings.json
@@ -7,6 +7,7 @@
   },
 
   "TestRequestTimeout": 180,
+  "ThinkTime":  500,
 
   "HostBotClientOptions": {
     "SimpleHostBotComposerDotNet": {


### PR DESCRIPTION
Addresses # 414

# Summary

This PRs adds a _think time_ in the test runner before sending activities to the bot to give it time to properly save the state, reducing the occurrences of the _conversation restarted_ issue.

## Specific changes

### TranscriptTestRunner
TestRunner.cs:
- Added ThinkTime variable set at creation with a default value of 0.
- Added a delay using the ThinkTime variable before sending the activity messages to the bot with the user role, using the value in milliseconds.
- Added log in the `RunTestAsync` method to include the ThinkTime and TestRequestTimeout values.
- Update the TimeRequestValue from seconds to milliseconds to have both variables consistent.

XUnitTestRunner.cs:
- Added ThinkTime variable to parse to the TestRunner.

### SkillsFunctionalTests
Added ThinkTime variable in the `appsettings.json` to be used in the test client creation with a value of 500.
Updated all the test client creations to include the ThinkTime.

Because the variable is set in the appsettings, it can be replaced/used by setting a variable `ThinkTime` in the pipeline, in which case that value will be used.

## Additional details

Adding this delay the _test scenarios_ pipelines increase their time from 10-20 minutes to 20-30 minutes.
Because of this, we will consider this change as temporary to allow the tests to pass while we look for better approaches that don't impact as much in the total time.

## Testing

To test the change we run a total of 35 _test scenarios_ pipelines, where no occurrence of the _conversation restarted_ issue showed up.
Below are some examples.
![image](https://user-images.githubusercontent.com/38112957/124017894-a0843f80-d9bd-11eb-849e-a22cf6eadc25.png)

Below can be seen the added logging and the ThinkTime set from the pipeline.
![image](https://user-images.githubusercontent.com/38112957/124290541-ec53f780-db29-11eb-967f-a031c0196139.png)