### PR TITLE
[#453][Pipelines] Update default resource group names to BFFN

### DIFF
--- a/build/yaml/cleanupResources/cleanupResources.yml
+++ b/build/yaml/cleanupResources/cleanupResources.yml
@@ -21,8 +21,8 @@ variables:
   InternalCosmosDBName: "bffnbotstatedb$($env:RESOURCESUFFIX)"
   InternalContainerRegistryName: "bffncontainerregistry$($env:RESOURCESUFFIX)"
   InternalKeyVaultName: "bffnbotkeyvault$($env:RESOURCESUFFIX)"
-  InternalBotResourceGroupName: $[coalesce(variables['DEPLOYRESOURCEGROUP'], 'bffnbots')]
-  InternalSharedResourceGroupName: $[coalesce(variables['SHAREDRESOURCEGROUP'], 'bffnshared')]
+  InternalBotResourceGroupName: $[coalesce(variables['DEPLOYRESOURCEGROUP'], 'BFFN')]
+  InternalSharedResourceGroupName: $[coalesce(variables['SHAREDRESOURCEGROUP'], 'BFFN-Shared')]
 
 pool:
   vmImage: "windows-2019"

--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -186,16 +186,16 @@ variables:
 
   ## Internal variables
   InternalAppInsightsName: 'bffnappinsights$(INTERNALRESOURCESUFFIX)'
-  InternalAppServicePlanWindowsResourceGroup: $[coalesce(variables['APPSERVICEPLANGROUP'], 'bffnshared')]
-  InternalAppServicePlanLinuxResourceGroup: $[coalesce(variables['APPSERVICEPLANGROUPLINUX'], 'bffnshared-linux')]
+  InternalAppServicePlanWindowsResourceGroup: $[coalesce(variables['APPSERVICEPLANGROUP'], 'BFFN-Shared')]
+  InternalAppServicePlanLinuxResourceGroup: $[coalesce(variables['APPSERVICEPLANGROUPLINUX'], 'BFFN-Shared-linux')]
   InternalAppServicePlanDotNetName: $[coalesce(variables['APPSERVICEPLANDOTNETNAME'], 'bffnbotsappservicedotnet$(INTERNALRESOURCESUFFIX)')]
   InternalAppServicePlanJSName: $[coalesce(variables['APPSERVICEPLANJSNAME'], 'bffnbotsappservicejs$(INTERNALRESOURCESUFFIX)')]
   InternalAppServicePlanPythonName: $[coalesce(variables['APPSERVICEPLANPYTHONNAME'], 'bffnbotsappservicepython$(INTERNALRESOURCESUFFIX)')]
   InternalContainerRegistryName: $[coalesce(variables['CONTAINERREGISTRYNAME'], 'bffncontainerregistry$(INTERNALRESOURCESUFFIX)')]
   InternalKeyVaultName: 'bffnbotkeyvault$(INTERNALRESOURCESUFFIX)'
-  InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'bffnbots')]
+  InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'BFFN')]
   InternalResourceSuffix: $[coalesce(variables['RESOURCESUFFIX'], '')]
-  InternalSharedResourceGroupName: $[coalesce(variables['SHAREDRESOURCEGROUP'], 'bffnshared')]
+  InternalSharedResourceGroupName: $[coalesce(variables['SHAREDRESOURCEGROUP'], 'BFFN-Shared')]
   InternalVirtualNetworkName: $[coalesce(variables['VIRTUALNETWORKNAME'], 'bffnvirtualnetwork$(INTERNALRESOURCESUFFIX)')]
 
 stages:

--- a/build/yaml/sharedResources/createSharedResources.yml
+++ b/build/yaml/sharedResources/createSharedResources.yml
@@ -26,7 +26,7 @@ variables:
   InternalContainerRegistryName: "bffncontainerregistry$($env:RESOURCESUFFIX)"
   InternalCosmosDBName: "bffnbotstatedb$($env:RESOURCESUFFIX)"
   InternalKeyVaultName: "bffnbotkeyvault$($env:RESOURCESUFFIX)"
-  InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUPNAME'], 'bffnshared')]
+  InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUPNAME'], 'BFFN-Shared')]
   InternalVirtualNetworkName: "bffnvirtualnetwork$($env:RESOURCESUFFIX)"
 
 stages:

--- a/build/yaml/testScenarios/runTestScenarios.yml
+++ b/build/yaml/testScenarios/runTestScenarios.yml
@@ -30,7 +30,7 @@ variables:
 
   ## Internal variables
   InternalKeyVaultName: "bffnbotkeyvault$(INTERNALRESOURCESUFFIX)"
-  InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'bffnbots')]
+  InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'BFFN')]
   InternalResourceSuffix: $[coalesce(variables['RESOURCESUFFIX'], '')]
 
 pool:


### PR DESCRIPTION
Fixes # 453

# Description
This PR updates all the pipelines default resource group naming to BFFN

## Specific changes

- `bffnbots` updated to `BFFN`, resulting in `BFFN-DotNet`, `BFFN-JS`, and `BFFN-Python`
- `bffnshared` updated to `BFFN-Shared`, resulting in `BFFN-Shared` for common resources and app services in windows and `BFFN-Shared` for app services in Linux

Change applied in the following YAML:
- cleanupResources.yml
- deployBotResources.yml
- createSharedResources.yml
- runTestScenarios.yml

## Testing

The resource groups look like the following image after creation when the default is used with the introduced changes.

![image](https://user-images.githubusercontent.com/38112957/124498770-45729400-dd93-11eb-8462-e042ec95b0e0.png)

The `create shared resources`,  `deploy bot resources`, `run test scenarios`, and `cleanup resources` pipelines were run to validate the changes.