### PR TITLE
[#447] Create utility script to generate appsettings.json

### DIFF
--- a/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
+++ b/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
@@ -173,7 +173,7 @@ $AppSettings.HostBotClientOptions.PSObject.Properties | ForEach-Object -Parallel
   $ResourceGroupSuffix = $GroupsSuffix | Where-Object { $Bot.Name -like "*$($_)*" };
   $ResourceGroup = "$ResourceGroup-$ResourceGroupSuffix";
 
-  $DirectLine = (az Bot directline show --name $Resource --resource-group $ResourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
+  $DirectLine = (az bot directline show --name $Resource --resource-group $ResourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
 
   $BotResource = @{
     Resource      = $Resource

--- a/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
+++ b/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
@@ -13,6 +13,15 @@
 
   .PARAMETER ResourceSuffix
   Specifies the suffix the resources name are built with.
+
+  .EXAMPLE
+  PS> .\ConfigureAppSettings.ps1 -ResourceGroup "BFFN-bots" -ResourceSuffix "{suffix}-{buildId}"
+
+  .EXAMPLE
+  PS> .\ConfigureAppSettings.ps1 -ResourceGroup "BFFN-bots"
+
+  .EXAMPLE
+  PS> .\ConfigureAppSettings.ps1
 #>
 
 param (

--- a/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
+++ b/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
@@ -6,8 +6,21 @@
   Gets DirectLine Secrets from Azure.
 
   .DESCRIPTION
-  Configure AppSettings file with DirectLine Secrets gather from Azure Bot Resources based on the Resource Group and Resource Suffix provided by the user.
+  Configure AppSettings file with DirectLine Secrets gathered from Azure Bot Resources based on the Resource Group and Resource Suffix provided by the user.
+
+  .PARAMETER ResourceGroup
+  Specifies the name for the specific Resource Group where the resources are deployed at.
+
+  .PARAMETER ResourceSuffix
+  Specifies the suffix the resources name are built with.
 #>
+
+param (
+    [Parameter(Mandatory=$false)]
+    [string]$ResourceGroup,
+    [Parameter(Mandatory=$false)]
+    [string]$ResourceSuffix
+)
 
 $PSVersion = $PSVersionTable.PSVersion;
 if ($PSVersion.Major -lt 7) {
@@ -49,26 +62,36 @@ if ($LoginOutput) {
 }
 
 # Resource Group Input
-Write-Host "? " -ForegroundColor Green -NoNewline;
-Write-Host "Enter the Resource Group where the Bots are located: " -ForegroundColor White -NoNewline;
-Write-Host "default (" -ForegroundColor DarkGray -NoNewline;
-Write-Host $Settings.ResourceGroup -ForegroundColor Magenta -NoNewline;
-Write-Host ") " -ForegroundColor DarkGray -NoNewline;
-$Inputs.ResourceGroup = (Read-Host).Trim();
+if ([string]::IsNullOrEmpty($ResourceGroup)) {
+  Write-Host "? " -ForegroundColor Green -NoNewline;
+  Write-Host "Enter the Resource Group where the Bots are located: " -ForegroundColor White -NoNewline;
+  Write-Host "default (" -ForegroundColor DarkGray -NoNewline;
+  Write-Host $Settings.ResourceGroup -ForegroundColor Magenta -NoNewline;
+  Write-Host ") " -ForegroundColor DarkGray -NoNewline;
+  $Inputs.ResourceGroup = (Read-Host).Trim();
+} 
+else {
+  $Inputs.ResourceGroup = $ResourceGroup;
+}
 
 # Resource Suffix Input
-do {
-  Write-Host "? " -ForegroundColor Green -NoNewline;
-  Write-Host "Enter the Suffix used for the Bot Resources: " -ForegroundColor White -NoNewline;
-  Write-Host "eg. (microsoft-396) " -ForegroundColor DarkGray -NoNewline;
-  $Inputs.ResourceSuffix = (Read-Host).Trim();
-  if ([string]::IsNullOrEmpty($Inputs.ResourceSuffix)) {
-    Write-Host "  - The Bot Resource Suffix must be provided" -ForegroundColor Red;
-  }
-  else {
-    break;
-  }
-} while ($true)
+if ([string]::IsNullOrEmpty($ResourceSuffix)) {
+  do {
+    Write-Host "? " -ForegroundColor Green -NoNewline;
+    Write-Host "Enter the Suffix used for the Bot Resources: " -ForegroundColor White -NoNewline;
+    Write-Host "eg. (microsoft-396) " -ForegroundColor DarkGray -NoNewline;
+    $Inputs.ResourceSuffix = (Read-Host).Trim();
+    if ([string]::IsNullOrEmpty($Inputs.ResourceSuffix)) {
+      Write-Host "  - The Bot Resource Suffix must be provided" -ForegroundColor Red;
+    }
+    else {
+      break;
+    }
+  } while ($true)
+} 
+else {
+  $Inputs.ResourceSuffix = $ResourceSuffix;
+}
 
 if ([string]::IsNullOrEmpty($Inputs.ResourceGroup)) {
   $Inputs.ResourceGroup = $Settings.ResourceGroup;

--- a/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
+++ b/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
@@ -1,0 +1,185 @@
+﻿# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+  .SYNOPSIS
+  Gets DirectLine Secrets from Azure.
+
+  .DESCRIPTION
+  Configure AppSettings file with DirectLine Secrets gather from Azure Bot Resources based on the Resource Group and Resource Suffix provided by the user.
+#>
+
+$PSVersion = $PSVersionTable.PSVersion;
+if ($PSVersion.Major -lt 7) {
+  Write-Host "`n==============================================================================================================================";
+  Write-Host "  This tool only supports " -ForegroundColor White -NoNewline;
+  Write-Host "PowerShell 7+" -ForegroundColor Magenta -NoNewline;
+  Write-Host "." -ForegroundColor White;
+  Write-Host "  PowerShell '" -ForegroundColor White -NoNewline;
+  Write-Host "$($PSVersion.Major).$($PSVersion.Minor)" -ForegroundColor Yellow -NoNewline;
+  Write-Host "' was detected!. To run this tool successfully, please upgrade PowerShell to version '" -ForegroundColor White -NoNewline;
+  Write-Host "7.0" -ForegroundColor Green -NoNewline;
+  Write-Host "' or higher." -ForegroundColor White;
+  Write-Host "  For more information, refer to the following documentation:" -ForegroundColor White;
+  Write-Host "   - https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-7.1" -ForegroundColor Cyan;
+  Write-Host "==============================================================================================================================`n";
+  exit 1;
+}
+
+$Inputs = @{};
+$RootFolder = Resolve-Path -Path "$PSScriptRoot\..";
+$Settings = @{
+  ResourceGroup      = 'BFFN'
+  GroupsSuffix       = @(
+    'DotNet'
+    'JS'
+    'Python'
+  )
+  AppSettingsPath    = "$RootFolder\appsettings.json";
+  AppSettingsDevPath = "$RootFolder\appsettings.Development.json";
+  BotSettings        = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
+  BotResources       = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
+}
+
+# Check if user is logged in
+$LoginOutput = az ad signed-in-user show --only-show-errors --output none 2>&1;
+if ($LoginOutput) {
+  $LoginOutput;
+  exit 1;
+}
+
+# Resource Group Input
+Write-Host "? " -ForegroundColor Green -NoNewline;
+Write-Host "Enter the Resource Group where the Bots are located: " -ForegroundColor White -NoNewline;
+Write-Host "default (" -ForegroundColor DarkGray -NoNewline;
+Write-Host $Settings.ResourceGroup -ForegroundColor Magenta -NoNewline;
+Write-Host ") " -ForegroundColor DarkGray -NoNewline;
+$Inputs.ResourceGroup = (Read-Host).Trim();
+
+# Resource Suffix Input
+do {
+  Write-Host "? " -ForegroundColor Green -NoNewline;
+  Write-Host "Enter the Suffix used for the Bot Resources: " -ForegroundColor White -NoNewline;
+  Write-Host "eg. (microsoft-396) " -ForegroundColor DarkGray -NoNewline;
+  $Inputs.ResourceSuffix = (Read-Host).Trim();
+  if ([string]::IsNullOrEmpty($Inputs.ResourceSuffix)) {
+    Write-Host "  - The Bot Resource Suffix must be provided" -ForegroundColor Red;
+  }
+  else {
+    break;
+  }
+} while ($true)
+
+if ([string]::IsNullOrEmpty($Inputs.ResourceGroup)) {
+  $Inputs.ResourceGroup = $Settings.ResourceGroup;
+}
+
+Write-Host "`nSummary" -ForegroundColor Cyan;
+Write-Host "  - Resource Group  : " -ForegroundColor Gray -NoNewline;
+Write-Host $Inputs.ResourceGroup -ForegroundColor Magenta;
+Write-Host "  - Resource Suffix : " -ForegroundColor Gray -NoNewline;
+Write-Host $Inputs.ResourceSuffix -ForegroundColor Magenta;
+
+# Read AppSettings
+Start-Sleep -Milliseconds 300;
+Write-Host "`nAttempting to read the AppSettings" -ForegroundColor Cyan;
+if (Test-Path -Path $Settings.AppSettingsDevPath -PathType Leaf) {
+  Write-Host "  - Using existing '$($Settings.AppSettingsDevPath)' file" -ForegroundColor Gray;
+}
+else {
+  Write-Host "  - Configuration file not found. Creating the '$($Settings.AppSettingsDevPath)' file" -ForegroundColor Gray;
+  if (-not (Test-Path -Path $Settings.AppSettingsPath  -PathType Leaf)) {
+    Write-Host "  - The 'appsettings.json' file to use as baseline was not found at '$($Settings.AppSettingsPath)'" -ForegroundColor Red;
+    exit 1;
+  }
+
+  Copy-Item -Path $Settings.AppSettingsPath  -Destination $Settings.AppSettingsDevPath
+  Write-Host "  - AppSettings file created" -ForegroundColor Gray;
+}
+
+$AppSettings = Get-Content $Settings.AppSettingsDevPath | ConvertFrom-Json;
+
+# Check Bot Resources existence
+Start-Sleep -Milliseconds 300;
+Write-Host "`nChecking Bot Resources" -ForegroundColor Cyan;
+Write-Host "  - Looking for Bot Resources existence..." -ForegroundColor Gray;
+$NonExistingResources = $AppSettings.HostBotClientOptions.PSObject.Properties | ForEach-Object -Parallel {
+  $GroupsSuffix = $using:Settings.GroupsSuffix;
+  $ResourceGroup = $using:Inputs.ResourceGroup;
+  $ResourceSuffix = $using:Inputs.ResourceSuffix;
+
+  $Bot = $_;
+  $BotId = "bffn$($Bot.Name)".ToLower();
+  $Resource = "$BotId$ResourceSuffix";
+  $ResourceGroupSuffix = $GroupsSuffix | Where-Object { $Bot.Name -like "*$($_)*" }
+  $ResourceGroup = "$ResourceGroup-$ResourceGroupSuffix";
+
+  $exists = (az webapp show --name $Resource --resource-group $ResourceGroup 2>$null | ConvertFrom-Json).enabled;
+
+  return [PSCustomObject]@{
+    Bot              = $Bot.Name
+    'Resource Group' = $ResourceGroup
+    Resource         = $Resource
+    Exists           = if ($exists) { $true } else { $false }
+  }
+} | Where-Object { $_.Exists -eq $false }
+
+if ($NonExistingResources) {
+  Write-Host "`nThe following Bot Resources were not found. Check if they're still available in Azure." -ForegroundColor Red;
+  $NonExistingResources | Select-Object 'Resource Group', 'Resource' | Format-Table -AutoSize;
+  exit 1;
+}
+else {
+  Write-Host "  - All Bot Resources were found" -ForegroundColor Gray;
+}
+
+# Configure AppSetting
+Start-Sleep -Milliseconds 300;
+Write-Host "`nConfiguring AppSettings" -ForegroundColor Cyan;
+Write-Host "  - Getting DirectLine Secrets from Bot Resources..." -ForegroundColor Gray;
+$AppSettings.HostBotClientOptions.PSObject.Properties | ForEach-Object -Parallel {
+  $GroupsSuffix = $using:Settings.GroupsSuffix;
+  $ResourceGroup = $using:Inputs.ResourceGroup;
+  $ResourceSuffix = $using:Inputs.ResourceSuffix;
+  $BotSettings = $using:Settings.BotSettings;
+  $BotResources = $using:Settings.BotResources;
+
+  $Bot = $_;
+  $BotId = "bffn$($Bot.Name)".ToLower();
+  $Resource = "$BotId$ResourceSuffix";
+  $ResourceGroupSuffix = $GroupsSuffix | Where-Object { $Bot.Name -like "*$($_)*" };
+  $ResourceGroup = "$ResourceGroup-$ResourceGroupSuffix";
+
+  $DirectLine = (az Bot directline show --name $Resource --resource-group $ResourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
+
+  $BotResource = @{
+    Resource      = $Resource
+    ResourceGroup = $ResourceGroup
+  }
+  $BotResources.TryAdd($Bot.Name, $BotResource) 1>$null;
+
+  $Settings = @{
+    BotId            = $Resource
+    DirectLineSecret = $DirectLine
+  }
+  $BotSettings.TryAdd($Bot.Name, $Settings) 1>$null;
+}
+
+$AppSettings.HostBotClientOptions = $Settings.BotSettings;
+
+$AppSettings | ConvertTo-Json | Set-Content $Settings.AppSettingsDevPath;
+Write-Host "  - AppSettings successfully configured" -ForegroundColor Gray;
+
+# Bot Configuration output
+Start-Sleep -Milliseconds 300;
+Write-Host "`nConfiguration saved" -ForegroundColor Cyan;
+$Settings.BotResources.GetEnumerator() | ForEach-Object { 
+  return [PSCustomObject]@{ 
+    Bot                 = $_.Key
+    'Resource Group'    = $_.Value.ResourceGroup
+    Resource            = $_.Value.Resource
+    'DirectLine Secret' = $Settings.BotSettings[$_.Key].DirectLineSecret
+  }
+} | Format-Table -AutoSize;
+
+Write-Host "Process Finished!" -ForegroundColor Green;

--- a/Tests/SkillFunctionalTests/Utils/README.md
+++ b/Tests/SkillFunctionalTests/Utils/README.md
@@ -1,0 +1,22 @@
+# Skills Functional Tests Utilities Scripts
+
+## ConfigureAppSettings
+
+This script configures the _appsettings.Development.json_ file from the SkillsFunctionalTest project to be able to run the tests locally connecting them with bots deployed in Azure. Its behavior consists on gathering the DirectLine Secrets from the deployed Azure Bot Resources and configure this file with them. For its purpose it uses the '**ResourceGroup**' and '**ResourceSuffix**' provided by the user when running it.
+
+>**ResourceGroup**: the specific Resource Group where the Azure Resoruce Bots are deployed in. The default value is 'BFFN'. _Eg: bffnbots_
+>
+>**ResourceSuffix**: the suffix the resources name are built with. It will be a combination of the suffix itself and the build id. _Eg: gitali-218_
+
+The user can execute the script providing one or both parameters and the process will being automatically, or execute it without parameters to insert them using the prompt.
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/54330145/124808628-899d9a00-df35-11eb-9b1c-bc88c352636a.png" />
+</p>
+
+The script will comunicate with azure through the **azure-cli** tool and gather the DirectLine secrets from each Azure Resource Bot deployed in the Resource Group resultant from the combination of the provided one with the language (DotNet, JS or Python) extracted from the _HostBotClientOptions_ keys, and '**ResourceSuffix**' parameter.
+
+Here you can see the entire process being executed
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/54330145/124788742-0756ab00-df20-11eb-8eea-8f54c07708f1.png" />
+</p>

--- a/Tests/SkillFunctionalTests/Utils/README.md
+++ b/Tests/SkillFunctionalTests/Utils/README.md
@@ -4,17 +4,17 @@
 
 This script configures the _appsettings.Development.json_ file from the SkillsFunctionalTest project to be able to run the tests locally connecting them with bots deployed in Azure. Its behavior consists on gathering the DirectLine Secrets from the deployed Azure Bot Resources and configure this file with them. For its purpose it uses the '**ResourceGroup**' and '**ResourceSuffix**' provided by the user when running it.
 
->**ResourceGroup**: the specific Resource Group where the Azure Resoruce Bots are deployed in. The default value is 'BFFN'. _Eg: bffnbots_
+>**ResourceGroup**: the specific Resource Group where the Azure Resource Bots are deployed in. The default value is 'BFFN'. _Eg: bffnbots_
 >
->**ResourceSuffix**: the suffix the resources name are built with. It will be a combination of the suffix itself and the build id. _Eg: gitali-218_
+>**ResourceSuffix**: the suffix the resources name is built with. It will be a combination of the suffix itself and the build id where the resource was created. _Eg: gitali-218_
 
-The user can execute the script providing one or both parameters and the process will being automatically, or execute it without parameters to insert them using the prompt.
+The user can execute the script providing one or both parameters and the process will start automatically, or execute it without parameters and provide them using the prompt.
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/54330145/124808628-899d9a00-df35-11eb-9b1c-bc88c352636a.png" />
 </p>
 
-The script will comunicate with azure through the **azure-cli** tool and gather the DirectLine secrets from each Azure Resource Bot deployed in the Resource Group resultant from the combination of the provided one with the language (DotNet, JS or Python) extracted from the _HostBotClientOptions_ keys, and '**ResourceSuffix**' parameter.
+The script will communicate with Azure through the **azure-cli** tool and gather the DirectLine secrets from each Azure Resource Bot deployed in the Resource Group resultant from the combination of the provided one with the language (DotNet, JS or Python) extracted from the _HostBotClientOptions_ keys, and '**ResourceSuffix**' parameter.
 
 Here you can see the entire process being executed
 <p align="center">


### PR DESCRIPTION
Fixes # 447

## Description
This PR adds a new script to configure the `appsettings.Development.json` file with `DirectLineSecrets` and `BotIds` for the `FunctionalTest` project.
To generate the `appsettings.Development.json` file, the script will use the `appsettings.json` as baseline, in case the development file already exists, it will be used as baseline instead.
When executing the script, two set of inputs must be provided, the Resource Group (optional, defaults to 'BFFN') and the Resource Suffix (combination of ResourceSuffix + BuildId variables).

We've also added a README file within the 'Utils' folder for detailing the script purpose, allowed inputs, process and behavior. This file will be useful in the future as a documentation for all 'Utilities Scripts' we could add.

## Specific Changes
- Script only supports PowerShell 7+, therefore a validation was added.
- Two parameters and input variables added (ResourceGroup and ResourceSuffix).
  - ResourceGroup: Name of the resource group where the bots are deployed, (without the DotNet, JS and Python suffixes).
  - ResourceSuffix: Combination of ResourceSuffix + BuildId variables.
  - If one or both of the parameters aren't provided when executing the script, the missing variables will be asked for the configuration.
- Step to create the `appsettings.Development.json` file to use as a source for the rest of the steps.
  - When the file doesn't exist, it will copy the `appsettings.json` file and use it as baseline.
  - When the file exists, it will continue the process.
- Step to corroborate that all bot resources are deployed and the DirectLineSecret can be retrived.
- Step to obtain the DirectLineSecret for each bot.
- Step to update the `appsettings.Development.json` file with all Bots' `DirectLineSecrets` and `BotIds` variables.
- Small sleep timeout of `300ms` was added to the script to have nicer message prompts.
- `README.md` file under 'Uitls' folder

## Testing
The following image shows how the script is executed.
![image](https://user-images.githubusercontent.com/62260472/124632687-f2fcaa80-de5a-11eb-8afa-1c0803dd4286.png)