### PR TITLE
Fix allowedCallers config for echoskillbotjs

### DIFF
--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/.env
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/.env
@@ -1,3 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
-AllowedCallers=
+AllowedCallers=*


### PR DESCRIPTION
#minor

## Description
This PR fixes the issue with allowed callers in [EchoSkillBotJS](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot).

## Detailed Changes
- Updated the .env file adding `*` to the allowedCallers configuration.

## Testing
This image shows the test pipeline working after the change.
![image](https://user-images.githubusercontent.com/44245136/124820771-47c82000-df44-11eb-9673-33a11f635772.png)
