### PR TITLE
[R13] Update BotBuilder version to latest 4.13.x in all projects

### DIFF
--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.3" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
@@ -25,9 +25,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.3" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 

--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/package.json
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com"
   },
   "dependencies": {
-    "botbuilder": "~4.13.3",
-    "botbuilder-dialogs": "~4.13.3",
+    "botbuilder": "~4.13.6",
+    "botbuilder-dialogs": "~4.13.6",
     "dotenv": "~8.2.0",
     "restify": "~8.5.1"
   },

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/package.json
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com"
   },
   "dependencies": {
-    "botbuilder": "~4.13.3",
-    "botbuilder-dialogs": "~4.13.3",
+    "botbuilder": "~4.13.6",
+    "botbuilder-dialogs": "~4.13.6",
     "dotenv": "~8.2.0",
     "restify": "~8.5.1"
   },

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/.env
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/.env
@@ -1,3 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
-AllowedCallers=*
+AllowedCallers=

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/authentication/allowedCallersClaimsValidator.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/authentication/allowedCallersClaimsValidator.js
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { JwtTokenValidation, SkillValidation } = require('botframework-connector');
+
+// Load the AppIds for the configured callers (we will only allow responses from skills we have configured).
+// process.env.AllowedCallers is the list of parent bot Ids that are allowed to access the skill
+// to add a new parent bot simply go to the .env file and add
+// the parent bot's Microsoft AppId to the list under AllowedCallers, e.g.:
+//  AllowedCallers=195bd793-4319-4a84-a800-386770c058b2,38c74e7a-3d01-4295-8e66-43dd358920f8
+const allowedCallers = process.env.AllowedCallers ? process.env.AllowedCallers.split(',') : undefined;
+
+/**
+ * Sample claims validator that loads an allowed list from configuration if present
+ * and checks that requests are coming from allowed parent bots.
+ * @param claims An array of Claims decoded from the HTTP request's auth header
+ */
+const allowedCallersClaimsValidator = async (claims) => {
+  // If allowedCallers is undefined we allow all calls
+  if (allowedCallers && SkillValidation.isSkillClaim(claims)) {
+    // Check that the appId claim in the skill request is in the list of skills configured for this bot.
+    const appId = JwtTokenValidation.getAppIdFromClaims(claims);
+    if (!allowedCallers.includes(appId)) {
+      throw new Error(`Received a request from a bot with an app ID of "${appId}". To enable requests from this caller, add the app ID to your configuration file.`);
+    }
+  }
+};
+
+module.exports.allowedCallersClaimsValidator = allowedCallersClaimsValidator;

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/bot.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/bot.js
@@ -1,16 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const {
-  ActivityHandler,
-  ActivityTypes,
-  EndOfConversationCodes
-} = require('botbuilder');
+const { ActivityHandler, ActivityTypes, EndOfConversationCodes } = require('botbuilder');
 
 class EchoBot extends ActivityHandler {
   constructor () {
     super();
-
     // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
     this.onMessage(async (context, next) => {
       const activityText = context.activity.text.toLowerCase();
@@ -22,16 +17,14 @@ class EchoBot extends ActivityHandler {
         });
       } else {
         await context.sendActivity(`Echo: ${context.activity.text}`);
-        await context.sendActivity(
-          'Say "end" or "stop" and I\'ll end the conversation and back to the parent.'
-        );
+        await context.sendActivity('Say "end" or "stop" and I\'ll end the conversation and back to the parent.');
       }
 
       // By calling next() you ensure that the next BotHandler is run.
       await next();
     });
 
-    this.onUnrecognizedActivityType(async (_context, next) => {
+    this.onUnrecognizedActivityType(async (context, next) => {
       // This will be called if the root bot is ending the conversation.  Sending additional messages should be
       // avoided as the conversation may have been deleted.
       // Perform cleanup of resources if needed.
@@ -42,4 +35,4 @@ class EchoBot extends ActivityHandler {
   }
 }
 
-module.exports = { EchoBot };
+module.exports.EchoBot = EchoBot;

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/index.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/index.js
@@ -1,93 +1,49 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Import required bot configuration.
-require('dotenv').config();
-
+const dotenv = require('dotenv');
 const http = require('http');
 const https = require('https');
+const path = require('path');
 const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const {
-  ActivityTypes,
-  CallerIdConstants,
-  CloudAdapter,
-  InputHints,
-  MessageFactory
-} = require('botbuilder');
+const { ActivityTypes, BotFrameworkAdapter, InputHints, MessageFactory } = require('botbuilder');
+const { AuthenticationConfiguration } = require('botframework-connector');
 
-const {
-  AuthenticationConfiguration,
-  AuthenticationConstants,
-  BotFrameworkAuthenticationFactory,
-  PasswordServiceClientCredentialFactory,
-  allowedCallersClaimsValidator
-} = require('botframework-connector');
+// Import required bot configuration.
+const ENV_FILE = path.join(__dirname, '.env');
+dotenv.config({ path: ENV_FILE });
 
 // This bot's main dialog.
-const { EchoBot } = require('./bot.js');
+const { EchoBot } = require('./bot');
+const { allowedCallersClaimsValidator } = require('./authentication/allowedCallersClaimsValidator');
 
 // Create HTTP server
-const server = restify.createServer({ maxParamLength: 1000 });
-server.use(restify.plugins.acceptParser(server.acceptable));
-server.use(restify.plugins.queryParser());
-server.use(restify.plugins.bodyParser());
-
+const server = restify.createServer();
 server.listen(process.env.port || process.env.PORT || 36400, () => {
   console.log(`\n${server.name} listening to ${server.url}`);
-  console.log(
-    '\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator'
-  );
+  console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
   console.log('\nTo talk to your bot, open the emulator select "Open Bot"');
 });
 
 // Expose the manifest
-server.get(
-  '/manifests/*',
-  restify.plugins.serveStatic({
-    directory: './manifests',
-    appendRequestPath: false
-  })
-);
+server.get('/manifests/*', restify.plugins.serveStatic({ directory: './manifests', appendRequestPath: false }));
 
-const maxTotalSockets = (
-  preallocatedSnatPorts,
-  procCount = 1,
-  weight = 0.5,
-  overcommit = 1.1
-) =>
+const maxTotalSockets = (preallocatedSnatPorts, procCount = 1, weight = 0.5, overcommit = 1.1) =>
   Math.min(
     Math.floor((preallocatedSnatPorts / procCount) * weight * overcommit),
     preallocatedSnatPorts
   );
 
-const allowedCallers =
-  (process.env.AllowedCallers || '').split(',').filter((val) => val) || [];
-
-const authConfig = new AuthenticationConfiguration(
-  [],
-  allowedCallersClaimsValidator(allowedCallers)
-);
-
-const botFrameworkAuthentication = BotFrameworkAuthenticationFactory.create(
-  '',
-  true,
-  AuthenticationConstants.ToChannelFromBotLoginUrl,
-  AuthenticationConstants.ToChannelFromBotOAuthScope,
-  AuthenticationConstants.ToBotFromChannelTokenIssuer,
-  AuthenticationConstants.OAuthUrl,
-  AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl,
-  AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
-  CallerIdConstants.PublicAzureChannel,
-  new PasswordServiceClientCredentialFactory(
-    process.env.MicrosoftAppId || '',
-    process.env.MicrosoftAppPassword || ''
-  ),
-  authConfig,
-  undefined,
-  {
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about how bots work.
+const adapter = new BotFrameworkAdapter({
+  appId: process.env.MicrosoftAppId,
+  appPassword: process.env.MicrosoftAppPassword,
+  authConfig: new AuthenticationConfiguration([], allowedCallersClaimsValidator),
+  clientOptions: {
     agentSettings: {
       http: new http.Agent({
         keepAlive: true,
@@ -99,11 +55,7 @@ const botFrameworkAuthentication = BotFrameworkAuthenticationFactory.create(
       })
     }
   }
-);
-
-// Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about how bots work.
-const adapter = new CloudAdapter(botFrameworkAuthentication);
+});
 
 // Catch-all for errors.
 adapter.onTurnError = async (context, error) => {
@@ -117,21 +69,12 @@ adapter.onTurnError = async (context, error) => {
 
     // Send a message to the user.
     let errorMessageText = 'The skill encountered an error or bug.';
-    let errorMessage = MessageFactory.text(
-      `${errorMessageText}\r\n${message}\r\n${stack}`,
-      errorMessageText,
-      InputHints.IgnoringInput
-    );
+    let errorMessage = MessageFactory.text(`${errorMessageText}\r\n${message}\r\n${stack}`, errorMessageText, InputHints.IgnoringInput);
     errorMessage.value = { message, stack };
     await context.sendActivity(errorMessage);
 
-    errorMessageText =
-      'To continue to run this bot, please fix the bot source code.';
-    errorMessage = MessageFactory.text(
-      errorMessageText,
-      errorMessageText,
-      InputHints.ExpectingInput
-    );
+    errorMessageText = 'To continue to run this bot, please fix the bot source code.';
+    errorMessage = MessageFactory.text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
     await context.sendActivity(errorMessage);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator
@@ -147,7 +90,7 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity({
       type: ActivityTypes.EndOfConversation,
       code: 'SkillError',
-      text: error.message
+      text: error
     });
   } catch (err) {
     console.error(`\n [onTurnError] Exception caught in onTurnError : ${err}`);
@@ -158,8 +101,8 @@ adapter.onTurnError = async (context, error) => {
 const myBot = new EchoBot();
 
 // Listen for incoming requests.
-server.post('/api/messages', async (req, res) => {
-  await adapter.process(req, res, async (context) => {
+server.post('/api/messages', (req, res) => {
+  adapter.processActivity(req, res, async (context) => {
     // Route to main dialog.
     await myBot.run(context);
   });

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com"
   },
   "dependencies": {
-    "botbuilder": "~4.13.3",
+    "botbuilder": "~4.13.6",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
@@ -1,20 +1,25 @@
 {
   "name": "echo-skill-bot",
-  "private": true,
+  "version": "1.0.0",
   "description": "Bot Builder v4 echo skill bot sample",
   "author": "Microsoft",
   "license": "MIT",
+  "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "nodemon index.js"
+    "start": "node ./index.js",
+    "watch": "nodemon ./index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com"
   },
   "dependencies": {
-    "botbuilder": "~4.14.0-rc0",
-    "botframework-connector": "~4.14.0-rc0",
-    "dotenv": "^10.0.0",
-    "restify": "^8.5.1"
+    "botbuilder": "~4.13.3",
+    "dotenv": "^8.2.0",
+    "restify": "~8.5.1"
   },
   "devDependencies": {
-    "nodemon": "^2.0.8"
+    "nodemon": "~2.0.4"
   }
 }

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/package.json
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com"
   },
   "dependencies": {
-    "botbuilder": "~4.13.3",
-    "botbuilder-dialogs": "~4.13.3",
+    "botbuilder": "~4.13.6",
+    "botbuilder-dialogs": "~4.13.6",
     "dotenv": "^8.2.0",
     "node-fetch": "^2.6.1",
     "restify": "~8.5.1"

--- a/Bots/JavaScript/yarn.lock
+++ b/Bots/JavaScript/yarn.lock
@@ -761,20 +761,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"botbuilder-core@npm:4.14.0-rc2":
-  version: 4.14.0-rc2
-  resolution: "botbuilder-core@npm:4.14.0-rc2"
-  dependencies:
-    botbuilder-dialogs-adaptive-runtime-core: 4.14.0-preview.rc2
-    botbuilder-stdlib: 4.14.0-internal.rc2
-    botframework-connector: 4.14.0-rc2
-    botframework-schema: 4.14.0-rc2
-    uuid: ^8.3.2
-    zod: ~1.11.17
-  checksum: 6a0a55bb576bdfb60e67d5779e7a663db9c546ef5520d75718e30389ddb0d6291fcdc7e7df104ba0443304b28ffe363d41a31ae961d59447be85328a02285cdf
-  languageName: node
-  linkType: hard
-
 "botbuilder-dialogs-adaptive-runtime-core@npm:4.13.6-preview":
   version: 4.13.6-preview
   resolution: "botbuilder-dialogs-adaptive-runtime-core@npm:4.13.6-preview"
@@ -785,16 +771,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"botbuilder-dialogs-adaptive-runtime-core@npm:4.14.0-preview.rc2":
-  version: 4.14.0-preview.rc2
-  resolution: "botbuilder-dialogs-adaptive-runtime-core@npm:4.14.0-preview.rc2"
-  dependencies:
-    dependency-graph: ^0.10.0
-  checksum: ae23051cb664122f4f40ab5753a1655f34b6b06596bba25d347b3c877dfc986de5da8c30680946a154afc3925f6c9ab4d4ff286821306e570429380d0839dda8
-  languageName: node
-  linkType: hard
-
-"botbuilder-dialogs@npm:~4.13.3":
+"botbuilder-dialogs@npm:~4.13.6":
   version: 4.13.6
   resolution: "botbuilder-dialogs@npm:4.13.6"
   dependencies:
@@ -818,13 +795,6 @@ __metadata:
   version: 4.13.6-internal
   resolution: "botbuilder-stdlib@npm:4.13.6-internal"
   checksum: d58cc6e32bc9a420ab32a749233fb2687b07181053135363d66401fd651220b9f07f9d5f506f093218661ee461ab54104a08fc729c317cd5f9531dc473adaea1
-  languageName: node
-  linkType: hard
-
-"botbuilder-stdlib@npm:4.14.0-internal.rc2":
-  version: 4.14.0-internal.rc2
-  resolution: "botbuilder-stdlib@npm:4.14.0-internal.rc2"
-  checksum: fa437e8cc3d689901ff3a24276e64d7de998a5ce573793b28e026c0dc13631fb391ad7464367049da0e3249bc6a6f0b5a76392c013f351d9b97f6e2454030f07
   languageName: node
   linkType: hard
 
@@ -855,7 +825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"botbuilder@npm:~4.13.3":
+"botbuilder@npm:~4.13.6":
   version: 4.13.6
   resolution: "botbuilder@npm:4.13.6"
   dependencies:
@@ -872,26 +842,6 @@ __metadata:
     htmlparser2: ^6.0.1
     uuid: ^8.3.2
   checksum: 526d47175fd4a2fe3a2556e7d3b05d5f758eb916740decdb8ac0a81c936b4524889c3b31c6975197553be8ac19da94d5065384d74686fe2ae10ea741c1ea2597
-  languageName: node
-  linkType: hard
-
-"botbuilder@npm:~4.14.0-rc0":
-  version: 4.14.0-rc2
-  resolution: "botbuilder@npm:4.14.0-rc2"
-  dependencies:
-    "@azure/ms-rest-js": 1.9.1
-    axios: ^0.21.1
-    botbuilder-core: 4.14.0-rc2
-    botbuilder-stdlib: 4.14.0-internal.rc2
-    botframework-connector: 4.14.0-rc2
-    botframework-streaming: 4.14.0-rc2
-    dayjs: ^1.10.3
-    filenamify: ^4.1.0
-    fs-extra: ^7.0.1
-    htmlparser2: ^6.0.1
-    uuid: ^8.3.2
-    zod: ~1.11.17
-  checksum: 324beaa09fb3870a03247f6b76925c05f1c61d7b193184c71f55dcb5abf2f1efe1edebe3da84a0e182af7b3534b6273c4390e89faf282036f7a8e2a5d2dc3a35
   languageName: node
   linkType: hard
 
@@ -912,25 +862,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"botframework-connector@npm:4.14.0-rc2, botframework-connector@npm:~4.14.0-rc0":
-  version: 4.14.0-rc2
-  resolution: "botframework-connector@npm:4.14.0-rc2"
-  dependencies:
-    "@azure/ms-rest-js": 1.9.1
-    "@types/jsonwebtoken": 7.2.8
-    "@types/node": ^10.17.27
-    adal-node: 0.2.2
-    axios: ^0.21.1
-    base64url: ^3.0.0
-    botbuilder-stdlib: 4.14.0-internal.rc2
-    botframework-schema: 4.14.0-rc2
-    cross-fetch: ^3.0.5
-    jsonwebtoken: 8.0.1
-    rsa-pem-from-mod-exp: ^0.8.4
-  checksum: 188c646db252281469786ee5964c394897995ef74ca604df14dead099a8681db77c2477e2928f5af5c532e7aba1e0b0ed4c24dfefe34d819f676e9ac6e71120d
-  languageName: node
-  linkType: hard
-
 "botframework-functional-tests@workspace:.":
   version: 0.0.0-use.local
   resolution: "botframework-functional-tests@workspace:."
@@ -948,16 +879,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"botframework-schema@npm:4.14.0-rc2":
-  version: 4.14.0-rc2
-  resolution: "botframework-schema@npm:4.14.0-rc2"
-  dependencies:
-    botbuilder-stdlib: 4.14.0-internal.rc2
-    uuid: ^8.3.2
-  checksum: 580a64fc1ebf6141497ed832025908f29a19b4dfafcb2a4b39897d6e66cab4696f793cb13ce8c0a5ea5138c47ecc9b595f49d6d01dac9159982124e2b7656541
-  languageName: node
-  linkType: hard
-
 "botframework-streaming@npm:4.13.6":
   version: 4.13.6
   resolution: "botframework-streaming@npm:4.13.6"
@@ -967,18 +888,6 @@ __metadata:
     uuid: ^8.3.2
     ws: ^7.1.2
   checksum: 08ebdff88c88f8c064f6a0effab308abcf5f5ddff2a1fea74e6e8d1d77782c31841d66ef3509b21d58a97f4c9760b0522495da16057f15a942be33e39bf153cc
-  languageName: node
-  linkType: hard
-
-"botframework-streaming@npm:4.14.0-rc2":
-  version: 4.14.0-rc2
-  resolution: "botframework-streaming@npm:4.14.0-rc2"
-  dependencies:
-    "@types/node": ^10.17.27
-    "@types/ws": ^6.0.3
-    uuid: ^8.3.2
-    ws: ^7.1.2
-  checksum: e069264b1adb922a3aee3ee3bee3962d46a8db5176a29a5ab121f96b88b9294af59fa1176d10d85f344bc6c5ccac0c01bd29614617e49aa00e2e69a387788e84
   languageName: node
   linkType: hard
 
@@ -1653,13 +1562,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "dotenv@npm:10.0.0"
-  checksum: 9c45712e213de63bdb646b8e5344749b7566e25a67bbd3f03711d54e40eff10066c1f23eff0081d0949fda7c8efcc6e9e8bf18d0f023a8274f55f5d5f97bb6db
-  languageName: node
-  linkType: hard
-
 "dotenv@npm:^8.2.0":
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
@@ -1714,11 +1616,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "echo-skill-bot@workspace:Skills/CodeFirst/EchoSkillBot"
   dependencies:
-    botbuilder: ~4.14.0-rc0
-    botframework-connector: ~4.14.0-rc0
-    dotenv: ^10.0.0
-    nodemon: ^2.0.8
-    restify: ^8.5.1
+    botbuilder: ~4.13.6
+    dotenv: ^8.2.0
+    nodemon: ~2.0.4
+    restify: ~8.5.1
   languageName: unknown
   linkType: soft
 
@@ -3952,7 +3853,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"nodemon@npm:^2.0.8, nodemon@npm:~2.0.4":
+"nodemon@npm:~2.0.4":
   version: 2.0.9
   resolution: "nodemon@npm:2.0.9"
   dependencies:
@@ -4996,8 +4897,8 @@ fsevents@~2.3.2:
   version: 0.0.0-use.local
   resolution: "simple-root-bot@workspace:Consumers/CodeFirst/SimpleHostBot"
   dependencies:
-    botbuilder: ~4.13.3
-    botbuilder-dialogs: ~4.13.3
+    botbuilder: ~4.13.6
+    botbuilder-dialogs: ~4.13.6
     dotenv: ~8.2.0
     nodemon: ~2.0.4
     restify: ~8.5.1
@@ -5758,8 +5659,8 @@ fsevents@~2.3.2:
   version: 0.0.0-use.local
   resolution: "waterfall-host-bot@workspace:Consumers/CodeFirst/WaterfallHostBot"
   dependencies:
-    botbuilder: ~4.13.3
-    botbuilder-dialogs: ~4.13.3
+    botbuilder: ~4.13.6
+    botbuilder-dialogs: ~4.13.6
     dotenv: ~8.2.0
     nodemon: ~2.0.4
     restify: ~8.5.1
@@ -5770,8 +5671,8 @@ fsevents@~2.3.2:
   version: 0.0.0-use.local
   resolution: "waterfall-skill-bot@workspace:Skills/CodeFirst/WaterfallSkillBot"
   dependencies:
-    botbuilder: ~4.13.3
-    botbuilder-dialogs: ~4.13.3
+    botbuilder: ~4.13.6
+    botbuilder-dialogs: ~4.13.6
     dotenv: ^8.2.0
     node-fetch: ^2.6.1
     nodemon: ~2.0.4
@@ -5936,12 +5837,5 @@ fsevents@~2.3.2:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: a2960ef879af6ee67a76cae29bac9d8bffeb6e9e366c217dbd21464e7fce071933705544724f47e90ba5209cf9c83c17d5582dd04415d86747a826b2a231efb8
-  languageName: node
-  linkType: hard
-
-"zod@npm:~1.11.17":
-  version: 1.11.17
-  resolution: "zod@npm:1.11.17"
-  checksum: 27e8799fa87ea4478a3155f40c39c4bef331b3c3273f00252ca646879c92eef54a5c36dcf31b6cd29bfd723fa4c1502e24d59e252d657183eab1252f273dfd7f
   languageName: node
   linkType: hard

--- a/Libraries/TranscriptConverter/TranscriptConverter.csproj
+++ b/Libraries/TranscriptConverter/TranscriptConverter.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.13.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveExpressions" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="AdaptiveExpressions" Version="4.13.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.3" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />


### PR DESCRIPTION
# Summary

This PR updates the BotBuilder versions in all bots to the latest 4.13.x available.
Also reverts the EchoSkillBot JS Cloud Adapter implementation to be compatible with the 4.13.6 version.
This way we get all the bots with the latest versions from R13 working.

## Specific changes

Update all BotBuilder packages to the latest 4.13.x versions.
- 4.13.3 for DotNet bots
- 4.13.6 for JS bots
- Python bots don't require an update, the latest stable version is 4.13.0

Revert EchoSkillBot JS cloud adapter implementation.

## Testing

Al all pipelines were run using the mentioned versions and the tests succeeded.
![image](https://user-images.githubusercontent.com/38112957/125500161-7b9f94c5-37fd-4db6-9b60-db524352b921.png)
![image](https://user-images.githubusercontent.com/38112957/125500169-08aa954c-9ee2-4f1e-a39c-c108292062a9.png)