### PR TITLE
[#473] Fix disappearing App Service Plans

### DIFF
--- a/build/yaml/common/deleteResourceGroup.yml
+++ b/build/yaml/common/deleteResourceGroup.yml
@@ -19,43 +19,72 @@ steps:
 
         function DeleteWebApps {
           param (
-            $ResourceGroup,
-            $TryLimit = 3,
-            $TryCount = 1
+            [String] $ResourceGroup,
+            [Int] $TryLimit = 3,
+            [Int] $TryCount = 1,
+            [System.Collections.Concurrent.ConcurrentDictionary[string, object]] $FailedWebApps = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
           )
-          
+
+          # Retry the Web App query in case it fails to retrive the full list.
+          for ($i = 1; $i -lt ($TryLimit + 1); $i++) {
+            $WebApps = az webapp list --resource-group $ResourceGroup | ConvertFrom-Json
+            if ($WebApps) {
+              Write-Host "  - Total of $($WebApps.Count) Web Apps were found!";
+              break;
+            }
+            elseif ($i -eq $TryLimit) {
+              Write-Host "  - [$($i)/$($TryLimit)] No more Web Apps were found!";
+            }
+            else {
+              Write-Host "  - [$($i)/$($TryLimit)] Looking for more Web Apps!";
+            }
+            Start-Sleep -Seconds 3;
+          }
+
+          if (-not $WebApps) {
+            if (-not $FailedWebApps.IsEmpty) {
+              Write-Host "  - Still there are Web Apps that failed, retrying the process!";
+              Write-Host $(@($FailedWebApps.Keys | ForEach-Object { "    - $($_)" }) -join "`n");
+              $WebApps = @($FailedWebApps.ToArray().Value);
+            }
+            else {
+              return $true;
+            }
+          }
+
           if ($TryCount -gt $TryLimit) {
             Write-Host "  - [$TryLimit/$TryLimit] Retry limit reached! Finishing the deletion process.";
             return $false;
           }
-          
-          $WebApps = az webapp list --resource-group $ResourceGroup | ConvertFrom-Json
-
-          if (-not $WebApps) {
-            Write-Host "  - All Web Apps were successfully deleted!";
-            return $true;
-          }
 
           Write-Host "  - [$TryCount/$TryLimit] Preparing to delete Web Apps under the Resource Group...";
-          $WebApps | ForEach-Object -Parallel {
+          $WebApps | ForEach-Object -ThrottleLimit 3 -Parallel {
+            $FailedWebApps = $using:FailedWebApps;
             $ResourceGroup = $using:ResourceGroup;
 
             $WebApp = $_;
-            $output = az webapp delete --name $WebApp.name --resource-group $ResourceGroup --keep-empty-plan 2>&1
+            $Output = az webapp delete --name $WebApp.name --resource-group $ResourceGroup --keep-empty-plan --only-show-errors 2>&1
             Write-Host "    - Deleting '$($WebApp.name)'...";
-            if ($output) { 
-              Write-Host  "    $output";
+            if ($Output) {
+              if ("$Output".Trim().StartsWith("ERROR")) {
+                $FailedWebApps.TryAdd($WebApp.name, $WebApp) 1>$null;
+              }
+              Write-Host  "      $Output";
+            }
+            else {
+              [System.Management.Automation.PSReference]$outVariable = @{};
+              $FailedWebApps.TryRemove($WebApp.name, [ref] $outVariable) 1>$null;
             }
           }
 
-          Start-Sleep -Seconds 3; 
-          return (DeleteWebApps -ResourceGroup $ResourceGroup -TryLimit $TryLimit -TryCount ($TryCount + 1))
+          Start-Sleep -Seconds 10;
+          return DeleteWebApps -ResourceGroup $ResourceGroup -TryLimit $TryLimit -TryCount ($TryCount + 1) -FailedWebApps $FailedWebApps
         }
 
         Write-Host "Looking for the Resource Group '$Group'...";
         if ((az group exists -n $Group) -eq "true") {
           Write-Host "  - Found pre-existing Resource Group!";
-          $DeletedWebApps = DeleteWebApps -ResourceGroup $Group;
+          $DeletedWebApps = DeleteWebApps -ResourceGroup $Group -TryLimit 5;
 
           if ($DeletedWebApps -eq $true) {
             Write-Host "  - Proceeding to the delete the Resource Group...";

--- a/build/yaml/common/deleteResourceGroup.yml
+++ b/build/yaml/common/deleteResourceGroup.yml
@@ -4,7 +4,7 @@ parameters:
   type: string
 
 - name: name
-  displayName: WebApp name
+  displayName: Resource Group name
   type: string
 
 steps:
@@ -15,23 +15,58 @@ steps:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        Write-Host "Looking for ${{ parameters.name }}..."
-        if ((az group exists -n "${{ parameters.name }}") -eq "true") {
-            Write-Host "Found pre-existing resource group ${{ parameters.name }}."
-            Write-Host "Starting resource cleanup..."
+        $Group = "${{ parameters.name }}";
 
-            $webapps = az webapp list --resource-group "${{ parameters.name }}" | ConvertFrom-Json
+        function DeleteWebApps {
+          param (
+            $ResourceGroup,
+            $TryLimit = 3,
+            $TryCount = 1
+          )
+          
+          if ($TryCount -gt $TryLimit) {
+            Write-Host "  - [$TryLimit/$TryLimit] Retry limit reached! Finishing the deletion process.";
+            return $false;
+          }
+          
+          $WebApps = az webapp list --resource-group $ResourceGroup | ConvertFrom-Json
 
-            foreach ($webapp in $webapps) {
-                Write-Host ("Deleting '" + $webapp.name + "'...")
-                az webapp delete --name $webapp.name --resource-group "${{ parameters.name }}" --keep-empty-plan
+          if (-not $WebApps) {
+            Write-Host "  - All Web Apps were successfully deleted!";
+            return $true;
+          }
+
+          Write-Host "  - [$TryCount/$TryLimit] Preparing to delete Web Apps under the Resource Group...";
+          $WebApps | ForEach-Object -Parallel {
+            $ResourceGroup = $using:ResourceGroup;
+
+            $WebApp = $_;
+            $output = az webapp delete --name $WebApp.name --resource-group $ResourceGroup --keep-empty-plan 2>&1
+            Write-Host "    - Deleting '$($WebApp.name)'...";
+            if ($output) { 
+              Write-Host  "    $output";
             }
+          }
 
-            Write-Host "Deleting ${{ parameters.name }}..."
-            az group delete -n "${{ parameters.name }}" --yes --no-wait
-            az group wait --deleted --interval 15 --timeout 600 --resource-group "${{ parameters.name }}"
+          Start-Sleep -Seconds 3; 
+          return (DeleteWebApps -ResourceGroup $ResourceGroup -TryLimit $TryLimit -TryCount ($TryCount + 1))
+        }
 
-            Write-Host "Pre-existing resource group ${{ parameters.name }} deleted."
-        } else {
-            Write-Host "No pre-existing resource group found."
+        Write-Host "Looking for the Resource Group '$Group'...";
+        if ((az group exists -n $Group) -eq "true") {
+          Write-Host "  - Found pre-existing Resource Group!";
+          $DeletedWebApps = DeleteWebApps -ResourceGroup $Group;
+
+          if ($DeletedWebApps -eq $true) {
+            Write-Host "  - Proceeding to the delete the Resource Group...";
+            az group delete -n $Group --yes --no-wait
+            az group wait --deleted --interval 15 --timeout 600 --resource-group $Group
+            Write-Host "    - Resource Group successfully deleted!";
+          }
+          else {
+            Write-Host "  - Unable to delete the Resource Group.";
+          }
+        }
+        else {
+          Write-Host "  - No pre-existing Resource Group found!";
         }


### PR DESCRIPTION
Fixes # 473

## Description
This PR fixes an issue when deleting the Web Apps connected to an App Service, the App Service will get deleted as well.
This issue was located in the `Deploy Bot Resources` pipeline under the `Delete pre-existing Resource Group` task, the cause could be due to multiple things, the ones we identified were:
- When deleting a Web App with the flag to keep the existing App Service Plan alive:
  - Will sometimes fail due to `Operation returned an invalid status code 'Too Many Requests'`, leaving a Web App created under the Resource Group.
  - The operation could never finish in the background, causing to continue executing the deletion of the Resource Group. 
  - Meaning by all above that, when deleting a Resource Group and at least one Web App still created inside, it will proceed to delete the Web App without the flag to keep the existing App Service Plan alive.
- Even if the process failed to delete the Web App due to an unexpected error, or in this case "Operation returned an invalid status code 'Too Many Requests' ", while checking if there were more Web Apps to be deleted, it didn’t find any. This caused a Web App to remain and then remove the Resource Group.
- There is a chance where the query fails to retrieve the Web Apps the first time, meaning there are no Web Apps to delete, therefore the process proceeds to delete the Resource Group.

The solution was to add a retry system only when still are Web Apps created under a specific Resource Group, and once finished, it will proceed to delete the Resource group.

Before applying the solution, **1 out of 3 pipelines failed due to an App Service plan disappearing**, after the applied solution, **up to 10 pipelines passed in a row with no errors**.

## Specific Changes
- Updates the `Delete pre-existing Resource Group` task adding a `DeleteWebApps` function to recursive evaluate if the process finished removing all Web Apps, otherwise it will retry up to five times.
  - After the process completes successfully, it will proceed to delete the Resource Group, otherwise it will skip on doing so to keep the App Service Plan alive.
  - Additional process information, the script keeps track 

## Testing
The following image shows the pipeline passing successfully and the output when the task fails and retries for the remaining Web Apps. Additionally, a list of up to 10 pipeline runs in a row with no App Service Plans disappearing.
![imagen](https://user-images.githubusercontent.com/62260472/126781013-dff6600b-112a-4553-91f2-a817ac0f9f12.png)
![imagen](https://user-images.githubusercontent.com/62260472/126783567-d9eb054a-0454-4421-bd42-6c0ce18e98c6.png)
