### PR TITLE
[#476] Feedback on ConfigureAppSettings.ps1 util

### DIFF
--- a/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
+++ b/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
@@ -9,7 +9,7 @@
   Configure AppSettings file with DirectLine Secrets gathered from Azure Bot Resources based on the Resource Group, Resource Suffix and Subscription provided by the user.
 
   .PARAMETER ResourceGroup
-  Specifies the Name for the specific Resource Group where the resources are deployed, For each specific language will concatenate (DotNet, JS and Python). Default (BFFN).
+  Specifies the Name for the specific Resource Group where the resources are deployed. For each specific language will concatenate (DotNet, JS and Python). Default (BFFN).
 
   .PARAMETER ResourceSuffix
   Specifies the Suffix used to concatenate at the end of the Resource Name followed up by the ResourceSuffixSeparator.
@@ -94,7 +94,7 @@ if ([string]::IsNullOrEmpty($Subscription)) {
   $Subscriptions = @(az account list | ConvertFrom-Json);
 
   if (-not $Subscriptions) {
-    Write-Host "There are no Subscriptions availables." -ForegroundColor Red;
+    Write-Host "There are no Subscriptions available." -ForegroundColor Red;
     exit 1;
   }
 

--- a/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
+++ b/Tests/SkillFunctionalTests/Utils/ConfigureAppSettings.ps1
@@ -6,29 +6,48 @@
   Gets DirectLine Secrets from Azure.
 
   .DESCRIPTION
-  Configure AppSettings file with DirectLine Secrets gathered from Azure Bot Resources based on the Resource Group and Resource Suffix provided by the user.
+  Configure AppSettings file with DirectLine Secrets gathered from Azure Bot Resources based on the Resource Group, Resource Suffix and Subscription provided by the user.
 
   .PARAMETER ResourceGroup
-  Specifies the name for the specific Resource Group where the resources are deployed at.
+  Specifies the Name for the specific Resource Group where the resources are deployed, For each specific language will concatenate (DotNet, JS and Python). Default (BFFN).
 
   .PARAMETER ResourceSuffix
-  Specifies the suffix the resources name are built with.
+  Specifies the Suffix used to concatenate at the end of the Resource Name followed up by the ResourceSuffixSeparator.
+
+  .PARAMETER Subscription
+  Specifies the Name or Id of the Subscription where the resources are located. Default (current Subscription).
+
+  .PARAMETER ResourceSuffixSeparator
+  Specifies the separator used for the Suffix to split the Resource Name from the ResourceSuffix. Default (-).
 
   .EXAMPLE
-  PS> .\ConfigureAppSettings.ps1 -ResourceGroup "BFFN-bots" -ResourceSuffix "{suffix}-{buildId}"
+  PS> .\ConfigureAppSettings.ps1 -ResourceGroup "bffnbots" -ResourceSuffix "{buildId}"
 
   .EXAMPLE
-  PS> .\ConfigureAppSettings.ps1 -ResourceGroup "BFFN-bots"
+  PS> .\ConfigureAppSettings.ps1 -ResourceGroup "bffnbots"
+
+  .EXAMPLE
+  PS> .\ConfigureAppSettings.ps1 -Subscription 00000000-0000-0000-0000-000000000000
+
+  .EXAMPLE
+  PS> .\ConfigureAppSettings.ps1 -Subscription bffnbots-subscription
+
+  .EXAMPLE
+  PS> .\ConfigureAppSettings.ps1 -ResourceSuffixSeparator "" -ResourceSuffix "microsoft-396"
 
   .EXAMPLE
   PS> .\ConfigureAppSettings.ps1
 #>
 
 param (
-    [Parameter(Mandatory=$false)]
-    [string]$ResourceGroup,
-    [Parameter(Mandatory=$false)]
-    [string]$ResourceSuffix
+  [Parameter(Mandatory = $false)]
+  [string]$Subscription,
+  [Parameter(Mandatory = $false)]
+  [string]$ResourceGroup,
+  [Parameter(Mandatory = $false)]
+  [string]$ResourceSuffixSeparator = "-",
+  [Parameter(Mandatory = $false)]
+  [string]$ResourceSuffix
 )
 
 $PSVersion = $PSVersionTable.PSVersion;
@@ -70,6 +89,69 @@ if ($LoginOutput) {
   exit 1;
 }
 
+# Subscription Input
+if ([string]::IsNullOrEmpty($Subscription)) {
+  $Subscriptions = @(az account list | ConvertFrom-Json);
+
+  if (-not $Subscriptions) {
+    Write-Host "There are no Subscriptions availables." -ForegroundColor Red;
+    exit 1;
+  }
+
+  $SubscriptionDefault = ($Subscriptions | Where-Object { $_.isDefault }) ?? $Subscriptions.GetValue(0);
+
+  if ($Subscriptions.Length -gt 1) {
+    do {
+      Write-Host "! " -ForegroundColor Yellow -NoNewline;
+      Write-Host "Multiple Subscriptions were found." -ForegroundColor White;
+  
+      $Subscriptions | Format-Table @(
+        @{Label = ' # '; Expression = { [array]::IndexOf($Subscriptions, $_) + 1 } },
+        @{Label = 'Name'; Expression = { $_.name } },
+        @{Label = 'Id'; Expression = { $_.id } },
+        @{Label = 'Default'; Expression = { $_.isDefault } }
+      ) -AutoSize
+
+      Write-Host "? " -ForegroundColor Green -NoNewline;
+      Write-Host "Enter a Subscription, by providing '#', 'Name' or 'Id': " -ForegroundColor White -NoNewline;
+      Write-Host "default (" -ForegroundColor DarkGray -NoNewline;
+      Write-Host $SubscriptionDefault.name -ForegroundColor Magenta -NoNewline;
+      Write-Host ") " -ForegroundColor DarkGray -NoNewline;
+
+      $UserInput = (Read-Host).Trim();
+    
+      if ([string]::IsNullOrEmpty($UserInput)) {
+        $SubscriptionInput = $SubscriptionDefault;
+        break;
+      }
+      else {
+        $SubscriptionInput = $Subscriptions | Where-Object {
+          $Sub = $_;
+          $Number = [array]::IndexOf($Subscriptions, $Sub) + 1;
+          if (@($Number, $Sub.id, $Sub.name) -contains $UserInput) {
+            return $true;
+          }
+        }
+  
+        if ($SubscriptionInput) {
+          break;
+        }
+        else {
+          Write-Host "  - A Subscription must be provided, could be either ('#', 'Name' or 'Id').`n" -ForegroundColor Red;
+        }
+      }
+    } while ($true)
+
+    $Inputs.Subscription = $SubscriptionInput.name;
+  }
+  else {
+    $Inputs.Subscription = $SubscriptionDefault.name;
+  }
+} 
+else {
+  $Inputs.Subscription = $Subscription;
+}
+
 # Resource Group Input
 if ([string]::IsNullOrEmpty($ResourceGroup)) {
   Write-Host "? " -ForegroundColor Green -NoNewline;
@@ -82,6 +164,9 @@ if ([string]::IsNullOrEmpty($ResourceGroup)) {
 else {
   $Inputs.ResourceGroup = $ResourceGroup;
 }
+
+# Resource Suffix Separator Input
+$Inputs.ResourceSuffixSeparator = $ResourceSuffixSeparator;
 
 # Resource Suffix Input
 if ([string]::IsNullOrEmpty($ResourceSuffix)) {
@@ -107,10 +192,14 @@ if ([string]::IsNullOrEmpty($Inputs.ResourceGroup)) {
 }
 
 Write-Host "`nSummary" -ForegroundColor Cyan;
-Write-Host "  - Resource Group  : " -ForegroundColor Gray -NoNewline;
+Write-Host "  - Subscription              : " -ForegroundColor Gray -NoNewline;
+Write-Host $Inputs.Subscription -ForegroundColor Magenta;
+Write-Host "  - Resource Group            : " -ForegroundColor Gray -NoNewline;
 Write-Host $Inputs.ResourceGroup -ForegroundColor Magenta;
-Write-Host "  - Resource Suffix : " -ForegroundColor Gray -NoNewline;
+Write-Host "  - Resource Suffix           : " -ForegroundColor Gray -NoNewline;
 Write-Host $Inputs.ResourceSuffix -ForegroundColor Magenta;
+Write-Host "  - Resource Suffix Separator : " -ForegroundColor Gray -NoNewline;
+Write-Host $Inputs.ResourceSuffixSeparator -ForegroundColor Magenta;
 
 # Read AppSettings
 Start-Sleep -Milliseconds 300;
@@ -138,27 +227,28 @@ Write-Host "  - Looking for Bot Resources existence..." -ForegroundColor Gray;
 $NonExistingResources = $AppSettings.HostBotClientOptions.PSObject.Properties | ForEach-Object -Parallel {
   $GroupsSuffix = $using:Settings.GroupsSuffix;
   $ResourceGroup = $using:Inputs.ResourceGroup;
+  $ResourceSuffixSeparator = $using:Inputs.ResourceSuffixSeparator;
   $ResourceSuffix = $using:Inputs.ResourceSuffix;
+  $Subscription = $using:Inputs.Subscription;
 
   $Bot = $_;
   $BotId = "bffn$($Bot.Name)".ToLower();
-  $Resource = "$BotId$ResourceSuffix";
+  $Resource = "$BotId$ResourceSuffixSeparator$ResourceSuffix";
   $ResourceGroupSuffix = $GroupsSuffix | Where-Object { $Bot.Name -like "*$($_)*" }
   $ResourceGroup = "$ResourceGroup-$ResourceGroupSuffix";
 
-  $exists = (az webapp show --name $Resource --resource-group $ResourceGroup 2>$null | ConvertFrom-Json).enabled;
+  $exists = (az webapp show --name $Resource --resource-group $ResourceGroup --subscription $Subscription 2>$null | ConvertFrom-Json).enabled;
 
   return [PSCustomObject]@{
-    Bot              = $Bot.Name
+    BotId            = $Resource
     'Resource Group' = $ResourceGroup
-    Resource         = $Resource
     Exists           = if ($exists) { $true } else { $false }
   }
-} | Where-Object { $_.Exists -eq $false }
+} | Where-Object { $_.Exists -eq $false } | Sort-Object -Property BotId
 
 if ($NonExistingResources) {
   Write-Host "`nThe following Bot Resources were not found. Check if they're still available in Azure." -ForegroundColor Red;
-  $NonExistingResources | Select-Object 'Resource Group', 'Resource' | Format-Table -AutoSize;
+  $NonExistingResources | Select-Object 'BotId', 'Resource Group' | Format-Table -AutoSize;
   exit 1;
 }
 else {
@@ -172,17 +262,19 @@ Write-Host "  - Getting DirectLine Secrets from Bot Resources..." -ForegroundCol
 $AppSettings.HostBotClientOptions.PSObject.Properties | ForEach-Object -Parallel {
   $GroupsSuffix = $using:Settings.GroupsSuffix;
   $ResourceGroup = $using:Inputs.ResourceGroup;
+  $ResourceSuffixSeparator = $using:Inputs.ResourceSuffixSeparator;
   $ResourceSuffix = $using:Inputs.ResourceSuffix;
+  $Subscription = $using:Inputs.Subscription;
   $BotSettings = $using:Settings.BotSettings;
   $BotResources = $using:Settings.BotResources;
 
   $Bot = $_;
   $BotId = "bffn$($Bot.Name)".ToLower();
-  $Resource = "$BotId$ResourceSuffix";
+  $Resource = "$BotId$ResourceSuffixSeparator$ResourceSuffix";
   $ResourceGroupSuffix = $GroupsSuffix | Where-Object { $Bot.Name -like "*$($_)*" };
   $ResourceGroup = "$ResourceGroup-$ResourceGroupSuffix";
 
-  $DirectLine = (az bot directline show --name $Resource --resource-group $ResourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
+  $DirectLine = (az bot directline show --name $Resource --resource-group $ResourceGroup --subscription $Subscription --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
 
   $BotResource = @{
     Resource      = $Resource
@@ -197,7 +289,9 @@ $AppSettings.HostBotClientOptions.PSObject.Properties | ForEach-Object -Parallel
   $BotSettings.TryAdd($Bot.Name, $Settings) 1>$null;
 }
 
-$AppSettings.HostBotClientOptions = $Settings.BotSettings;
+$SortedBotSettings = [ordered]@{};
+$Settings.BotSettings.GetEnumerator() | Sort-Object -Property Key | ForEach-Object { $SortedBotSettings[$_.Key] = $_.Value };
+$AppSettings.HostBotClientOptions = $SortedBotSettings;
 
 $AppSettings | ConvertTo-Json | Set-Content $Settings.AppSettingsDevPath;
 Write-Host "  - AppSettings successfully configured" -ForegroundColor Gray;
@@ -207,11 +301,10 @@ Start-Sleep -Milliseconds 300;
 Write-Host "`nConfiguration saved" -ForegroundColor Cyan;
 $Settings.BotResources.GetEnumerator() | ForEach-Object { 
   return [PSCustomObject]@{ 
-    Bot                 = $_.Key
-    'Resource Group'    = $_.Value.ResourceGroup
-    Resource            = $_.Value.Resource
+    BotId               = $_.Value.Resource
     'DirectLine Secret' = $Settings.BotSettings[$_.Key].DirectLineSecret
+    'Resource Group'    = $_.Value.ResourceGroup
   }
-} | Format-Table -AutoSize;
+} | Sort-Object -Property BotId | Format-Table -AutoSize;
 
 Write-Host "Process Finished!" -ForegroundColor Green;

--- a/Tests/SkillFunctionalTests/Utils/README.md
+++ b/Tests/SkillFunctionalTests/Utils/README.md
@@ -17,7 +17,7 @@ For the process to be able to find the resources, the following inputs must be p
 
 | Input                   | Description                                                                                                                                                   | Condition | Default              | Example                                                           |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------------------- | ----------------------------------------------------------------- |
-| ResourceGroup           | The Name for the specific Resource Group where the resources are deployed, For each specific language will concatenate (DotNet, JS and Python).               | Required  | BFFN                 | "bffnbots"                                                        |
+| ResourceGroup           | The Name for the specific Resource Group where the resources are deployed. For each specific language will concatenate (DotNet, JS and Python).               | Required  | BFFN                 | "bffnbots"                                                        |
 | ResourceSuffix          | The Suffix used to concatenate at the end of the Resource Name followed up by the ResourceSuffixSeparator.                                                    | Required  |                      | "microsoft-396"                                                   |
 | Subscription            | The Name or Id of the Subscription where the resources are located.                                                                                           | Optional  | Current Subscription | "00000000-0000-0000-0000-000000000000" or "bffnbots-subscription" |
 | ResourceSuffixSeparator | The separator used for the Suffix to split the Resource Name from the ResourceSuffix. <br> **Note:** _Only available when providing it through `parameters`_. | Optional  | -                    | "" or "-microsoft-"                                               |
@@ -38,7 +38,7 @@ After providing the desired [Inputs][inputs], the script will start looking for 
 
 ![sample][sample]
 
-> **Note:** When not `appsettings.Development.json` file is found, it will proceed by generating a copy from the `appsettings.json` baseline file.
+> **Note:** When no `appsettings.Development.json` file is found, it will proceed by generating a copy from the `appsettings.json` baseline file.
 
 > **Note:** Applies to `Subscription` input. When multiple Subscriptions are detected, a prompt to choose the desired one will appear. `Can be entered by Number (#), Name or Id`, otherwise the `default` one will be used instead.
 

--- a/Tests/SkillFunctionalTests/Utils/README.md
+++ b/Tests/SkillFunctionalTests/Utils/README.md
@@ -2,21 +2,59 @@
 
 ## ConfigureAppSettings
 
-This script configures the _appsettings.Development.json_ file from the SkillsFunctionalTest project to be able to run the tests locally connecting them with bots deployed in Azure. Its behavior consists on gathering the DirectLine Secrets from the deployed Azure Bot Resources and configure this file with them. For its purpose it uses the '**ResourceGroup**' and '**ResourceSuffix**' provided by the user when running it.
+### Description
 
->**ResourceGroup**: the specific Resource Group where the Azure Resource Bots are deployed in. The default value is 'BFFN'. _Eg: bffnbots_
->
->**ResourceSuffix**: the suffix the resources name is built with. It will be a combination of the suffix itself and the build id where the resource was created. _Eg: gitali-218_
+This script configures the `appsettings.Development.json` file from the SkillsFunctionalTest project to be able to run the tests locally, connecting them with bots deployed in Azure. Its behavior consists on gathering the DirectLine Secrets from the deployed Azure Bot Resources and configure this file with them.
 
-The user can execute the script providing one or both parameters and the process will start automatically, or execute it without parameters and provide them using the prompt.
+For the process to be able to find the resources, the following inputs must be provided.
 
-<p align="center">
-  <img src="https://user-images.githubusercontent.com/54330145/124808628-899d9a00-df35-11eb-9b1c-bc88c352636a.png" />
-</p>
+### Requirements
 
-The script will communicate with Azure through the **azure-cli** tool and gather the DirectLine secrets from each Azure Resource Bot deployed in the Resource Group resultant from the combination of the provided one with the language (DotNet, JS or Python) extracted from the _HostBotClientOptions_ keys, and '**ResourceSuffix**' parameter.
+- [Azure CLI][azure-cli]
+- [PowerShell 7+][powershell]
 
-Here you can see the entire process being executed
-<p align="center">
-  <img src="https://user-images.githubusercontent.com/54330145/124788742-0756ab00-df20-11eb-8eea-8f54c07708f1.png" />
-</p>
+### Inputs
+
+| Input                   | Description                                                                                                                                                   | Condition | Default              | Example                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------------------- | ----------------------------------------------------------------- |
+| ResourceGroup           | The Name for the specific Resource Group where the resources are deployed, For each specific language will concatenate (DotNet, JS and Python).               | Required  | BFFN                 | "bffnbots"                                                        |
+| ResourceSuffix          | The Suffix used to concatenate at the end of the Resource Name followed up by the ResourceSuffixSeparator.                                                    | Required  |                      | "microsoft-396"                                                   |
+| Subscription            | The Name or Id of the Subscription where the resources are located.                                                                                           | Optional  | Current Subscription | "00000000-0000-0000-0000-000000000000" or "bffnbots-subscription" |
+| ResourceSuffixSeparator | The separator used for the Suffix to split the Resource Name from the ResourceSuffix. <br> **Note:** _Only available when providing it through `parameters`_. | Optional  | -                    | "" or "-microsoft-"                                               |
+
+### The inputs can be provided as `prompts` or `parameters`
+
+1. When using `prompts`, it will ask for the `required` inputs to be provided. When no input is entered, it will use the `default (...)` value instead. For more information about, see [Inputs][inputs].
+
+   ![prompts][prompts]
+
+2. When using `parameters`, all listed inputs can be provided before executing the script. When no input is entered, it will use the `default` value instead. For more information, see [Inputs][inputs].
+
+   ![parameters][parameters]
+
+### Result
+
+After providing the desired [Inputs][inputs], the script will start looking for the Bot Resources, followed up by gathering each DirectLine Secret from the Azure Bot Resource and set it in the `appsettings.Development.json`. Moreover, all steps will be shown in the terminal as well as the result with each DirectLine Secret set for each Bot.
+
+![sample][sample]
+
+> **Note:** When not `appsettings.Development.json` file is found, it will proceed by generating a copy from the `appsettings.json` baseline file.
+
+> **Note:** Applies to `Subscription` input. When multiple Subscriptions are detected, a prompt to choose the desired one will appear. `Can be entered by Number (#), Name or Id`, otherwise the `default` one will be used instead.
+
+> **Note:** Applies to all `Inputs`. A mix between the two ways (`prompts` and `parameters`) to provide the inputs can be used. _E.g. prompts: ResourceSuffix and ResourceGroup, parameters: Subscription and ResourceSuffixSeparator_.
+
+<!-- Requirements -->
+
+[azure-cli]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+[powershell]: https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.1
+
+<!-- Inputs -->
+
+[inputs]: #inputs
+
+<!-- Images -->
+
+[prompts]: https://user-images.githubusercontent.com/62260472/134236938-b85fd5a1-6e32-4b78-a67f-cf9d8d98c3b4.png
+[parameters]: https://user-images.githubusercontent.com/62260472/134376619-aa7c27b7-52e6-4d72-837a-ec92e59afff6.png
+[sample]: https://user-images.githubusercontent.com/62260472/134376693-f8c109f8-a735-4be1-a601-5fdfb087078a.png


### PR DESCRIPTION
Fixes # 476

## Description
This PR updates the `ConfigureAppSettings.ps1` script by providing the ability to recognize and provide a desired `Subscription`. The dash (`-`) symbol now can be changed using the `ResourceSuffixSeparator`, this allows to enter the `ResourceSuffix` without the character, and at the same time providing the possibility to change the separator. Moreover, both output and file generated with the DirectLine Secrets are alphabetically ordered by `BotId`.
Not only that, we improved the `README.md` including all the new and old functionality.

## Specific Changes
- Adds the `Subscription` input, the user will be prompted to choose a subscription when multiples are detected, otherwise it will use the default one.
- Adds the `ResourceSuffixSeparator` parameter, allowing the user to change the separator used between the Bot's name and the `ResourceSuffix`. Default value is a dash (`-`).
- Improved script output by making the Bots' table ordered by `BotId`. This also apply to the `HostBotClientOptions` property in the `appsettings.json`.
- Improved `README.md` by including the new functionality, adding the list of inputs the script requires, new images and notes.

## Testing
The following image shows the script when multiple subscriptions are detected.
![image](https://user-images.githubusercontent.com/62260472/134394293-057e9364-a91b-465e-ba7f-2018d9b3057e.png)