### PR TITLE
[#503] Apply workaround for restify.server.url in WaterfallSkillBotJS

### DIFF
--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/bots/skillBot.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/bots/skillBot.js
@@ -6,18 +6,19 @@ const { runDialog } = require('botbuilder-dialogs');
 
 class SkillBot extends ActivityHandler {
   /**
+   * @param {import('../config').DefaultConfig} configuration
    * @param {import('botbuilder').ConversationState} conversationState
    * @param {import('botbuilder-dialogs').Dialog} dialog
-   * @param {string} serverUrl
    */
-  constructor (conversationState, dialog, serverUrl) {
+  constructor (configuration, conversationState, dialog) {
     super();
+    if (!configuration) throw new Error('[SkillBot]: Missing parameter. configuration is required');
     if (!conversationState) throw new Error('[SkillBot]: Missing parameter. conversationState is required');
     if (!dialog) throw new Error('[SkillBot]: Missing parameter. dialog is required');
 
+    this.configuration = configuration;
     this.conversationState = conversationState;
     this.dialog = dialog;
-    this.serverUrl = serverUrl;
 
     this.onTurn(async (turnContext, next) => {
       if (turnContext.activity.type !== ActivityTypes.ConversationUpdate) {
@@ -37,7 +38,7 @@ class SkillBot extends ActivityHandler {
             text,
             speak: text.replace('\n\n', '')
           });
-          await turnContext.sendActivity(`You can check the skill manifest to see what it supports here: ${this.serverUrl}/manifests/waterfallskillbot-manifest-1.0.json`);
+          await turnContext.sendActivity(`You can check the skill manifest to see what it supports here: ${this.configuration.ServerUrl}/manifests/waterfallskillbot-manifest-1.0.json`);
         }
       }
 

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/config.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/config.js
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Bot Configuration
+ */
+class DefaultConfig {
+  constructor () {
+    const {
+      MicrosoftAppId,
+      MicrosoftAppPassword,
+      ConnectionName,
+      SsoConnectionName,
+      ChannelService,
+      AllowedCallers,
+      SkillHostEndpoint,
+      port,
+      PORT
+    } = process.env;
+
+    this.ServerUrl = '';
+    this.Port = port || PORT || 36420;
+    this.MicrosoftAppId = MicrosoftAppId;
+    this.MicrosoftAppPassword = MicrosoftAppPassword;
+    this.ConnectionName = ConnectionName;
+    this.SsoConnectionName = SsoConnectionName;
+    this.ChannelService = ChannelService;
+    this.SkillHostEndpoint = SkillHostEndpoint;
+    // To add a new parent bot, simply edit the .env file and add
+    // the parent bot's Microsoft AppId to the list under AllowedCallers, e.g.:
+    // AllowedCallers=195bd793-4319-4a84-a800-386770c058b2,38c74e7a-3d01-4295-8e66-43dd358920f8
+    this.AllowedCallers = (AllowedCallers || '').split(',').filter((val) => val) || [];
+    this.EchoSkillInfo = {
+      id: process.env.EchoSkillInfo_id,
+      appId: process.env.EchoSkillInfo_appId,
+      skillEndpoint: process.env.EchoSkillInfo_skillEndpoint
+    };
+  }
+
+  /**
+   * @param {import('restify').Request} request
+   */
+  configureServerUrl (request) {
+    // Workaround for Restify known issues to construct the server.url.
+    // Restify:
+    //   [#1029](https://github.com/restify/node-restify/issues/1029)
+    //   [#1274](https://github.com/restify/node-restify/issues/1274)
+    const protocol = request.headers['x-appservice-proto'] ?? 'http';
+    const url = process.env.WEBSITE_HOSTNAME ?? request.headers.host;
+    this.ServerUrl = `${protocol}://${url}`;
+  }
+}
+
+module.exports.DefaultConfig = DefaultConfig;

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/activityRouterDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/activityRouterDialog.js
@@ -29,24 +29,24 @@ const UPDATE_DIALOG = 'Update';
  */
 class ActivityRouterDialog extends ComponentDialog {
   /**
-   * @param {string} serverUrl
+   * @param {import('../config').DefaultConfig} configuration
    * @param {import('botbuilder').ConversationState} conversationState
-   * @param {import('../skillConversationIdFactory').SkillConversationIdFactory} conversationIdFactory
+   * @param {import('botbuilder').SkillConversationIdFactory} conversationIdFactory
    * @param {import('botbuilder').SkillHttpClient} skillClient
    * @param {Object<string, import('./proactive/continuationParameters').ContinuationParameters>} continuationParametersStore
    */
-  constructor (serverUrl, conversationState, conversationIdFactory, skillClient, continuationParametersStore) {
+  constructor (configuration, conversationState, conversationIdFactory, skillClient, continuationParametersStore) {
     super(MAIN_DIALOG);
 
-    this.addDialog(new CardDialog(CARDS_DIALOG, serverUrl))
-      .addDialog(new WaitForProactiveDialog(PROACTIVE_DIALOG, serverUrl, continuationParametersStore))
-      .addDialog(new MessageWithAttachmentDialog(ATTACHMENT_DIALOG, serverUrl))
-      .addDialog(new AuthDialog(AUTH_DIALOG, process.env))
-      .addDialog(new SsoSkillDialog(SSO_DIALOG, process.env))
+    this.addDialog(new CardDialog(CARDS_DIALOG, configuration))
+      .addDialog(new WaitForProactiveDialog(PROACTIVE_DIALOG, configuration, continuationParametersStore))
+      .addDialog(new MessageWithAttachmentDialog(ATTACHMENT_DIALOG, configuration))
+      .addDialog(new AuthDialog(AUTH_DIALOG, configuration))
+      .addDialog(new SsoSkillDialog(SSO_DIALOG, configuration))
       .addDialog(new FileUploadDialog(FILE_UPLOAD_DIALOG))
       .addDialog(new DeleteDialog(DELETE_DIALOG))
       .addDialog(new UpdateDialog(UPDATE_DIALOG))
-      .addDialog(this.createEchoSkillDialog(ECHO_DIALOG, conversationState, conversationIdFactory, skillClient, process.env))
+      .addDialog(this.createEchoSkillDialog(ECHO_DIALOG, configuration, conversationState, conversationIdFactory, skillClient))
       .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
         this.processActivity.bind(this)
       ]));
@@ -56,22 +56,18 @@ class ActivityRouterDialog extends ComponentDialog {
 
   /**
    * @param {string} dialogId
+   * @param {import('../config').DefaultConfig} configuration
    * @param {import('botbuilder').ConversationState} conversationState
-   * @param {import('../skillConversationIdFactory').SkillConversationIdFactory} conversationIdFactory
+   * @param {import('botbuilder').SkillConversationIdFactory} conversationIdFactory
    * @param {import('botbuilder').SkillHttpClient} skillClient
-   * @param {Object} configuration
    */
-  createEchoSkillDialog (dialogId, conversationState, conversationIdFactory, skillClient, configuration) {
+  createEchoSkillDialog (dialogId, configuration, conversationState, conversationIdFactory, skillClient) {
     const skillHostEndpoint = configuration.SkillHostEndpoint;
     if (!skillHostEndpoint) {
       throw new Error('SkillHostEndpoint is not in configuration');
     }
 
-    const skill = {
-      id: configuration.EchoSkillInfo_id,
-      appId: configuration.EchoSkillInfo_appId,
-      skillEndpoint: configuration.EchoSkillInfo_skillEndpoint
-    };
+    const skill = configuration.EchoSkillInfo;
 
     if (!skill.id || !skill.skillEndpoint) {
       throw new Error('EchoSkillInfo_id and EchoSkillInfo_skillEndpoint are not set in configuration');

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/auth/authDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/auth/authDialog.js
@@ -11,7 +11,7 @@ const CONFIRM_PROMPT = 'ConfirmPrompt';
 class AuthDialog extends ComponentDialog {
   /**
    * @param {string} dialogId
-   * @param {Object} configuration
+   * @param {import('../../config').DefaultConfig} configuration
    */
   constructor (dialogId, configuration) {
     super(dialogId);

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/cardDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/cardDialog.js
@@ -15,12 +15,12 @@ const CARD_PROMPT = 'CardPrompt';
 class CardDialog extends ComponentDialog {
   /**
    * @param {string} dialogId
-   * @param {string} serverUrl
+   * @param {import('../../config').DefaultConfig} configuration
    */
-  constructor (dialogId, serverUrl) {
+  constructor (dialogId, configuration) {
     super(dialogId);
 
-    this.serverUrl = serverUrl;
+    this.configuration = configuration;
     this.mindBlownGif = 'https://media3.giphy.com/media/xT0xeJpnrWC4XWblEk/giphy.gif?cid=ecf05e47mye7k75sup6tcmadoom8p1q8u03a7g2p3f76upp9&rid=giphy.gif';
     this.corgiOnCarouselVideo = 'https://www.youtube.com/watch?v=LvqzubPZjHE';
     this.teamsLogoFileName = 'teams-logo.png';
@@ -150,7 +150,7 @@ class CardDialog extends ComponentDialog {
             break;
 
           case CardOptions.Audio:
-            await stepContext.context.sendActivity(MessageFactory.attachment(CardSampleHelper.createAudioCard(`${this.serverUrl}/api/music`)));
+            await stepContext.context.sendActivity(MessageFactory.attachment(CardSampleHelper.createAudioCard(`${this.configuration.ServerUrl}/api/music`)));
             break;
 
           case CardOptions.Video:

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/messageWithAttachment/messageWithAttachmentDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/messageWithAttachment/messageWithAttachmentDialog.js
@@ -13,13 +13,13 @@ const WATERFALL_DIALOG = 'WaterfallDialog';
 class MessageWithAttachmentDialog extends ComponentDialog {
   /**
    * @param {string} dialogId
-   * @param {string} serverUrl
+   * @param {import('../../config').DefaultConfig} configuration
    */
-  constructor (dialogId, serverUrl) {
+  constructor (dialogId, configuration) {
     super(dialogId);
 
     this.picture = 'architecture-resize.png';
-    this.serverUrl = serverUrl;
+    this.configuration = configuration;
 
     this.addDialog(new ChoicePrompt(ATTACHMENT_TYPE_PROMPT))
       .addDialog(new ConfirmPrompt(CONFIRM_PROMPT))
@@ -116,7 +116,7 @@ class MessageWithAttachmentDialog extends ComponentDialog {
     return {
       name: `Files/${this.picture}`,
       contentType: 'image/png',
-      contentUrl: `${this.serverUrl}/images/architecture-resize.png`
+      contentUrl: `${this.configuration.ServerUrl}/images/architecture-resize.png`
     };
   }
 }

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/proactive/waitForProactiveDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/proactive/waitForProactiveDialog.js
@@ -7,22 +7,21 @@ const { Dialog, DialogTurnStatus } = require('botbuilder-dialogs');
 class WaitForProactiveDialog extends Dialog {
   /**
    * @param {string} dialogId
-   * @param {string} serverUrl
+   * @param {import('../../config').DefaultConfig} configuration
    * @param {Object<string, import('./continuationParameters').ContinuationParameters>} continuationParametersStore
    */
-  constructor (dialogId, serverUrl, continuationParametersStore) {
+  constructor (dialogId, configuration, continuationParametersStore) {
     super(dialogId);
-    this.serverUrl = serverUrl;
+    this.configuration = configuration;
     this.continuationParametersStore = continuationParametersStore;
   }
 
   /**
    * Message to send to users when the bot receives a Conversation Update event
-   * @param {string} url
    * @param {string} id
    */
-  notifyMessage (url, id) {
-    return `Navigate to ${url}/api/notify?user=${id} to proactively message the user.`;
+  notifyMessage (id) {
+    return `Navigate to ${this.configuration.ServerUrl}/api/notify?user=${id} to proactively message the user.`;
   }
 
   /**
@@ -33,7 +32,7 @@ class WaitForProactiveDialog extends Dialog {
     this.addOrUpdateContinuationParameters(dc.context);
 
     // Render message with continuation link.
-    await dc.context.sendActivity(MessageFactory.text(this.notifyMessage(this.serverUrl, dc.context.activity.from.id)));
+    await dc.context.sendActivity(MessageFactory.text(this.notifyMessage(dc.context.activity.from.id)));
     return Dialog.EndOfTurn;
   }
 
@@ -58,7 +57,7 @@ class WaitForProactiveDialog extends Dialog {
     }
 
     // Keep waiting for a call to the ProactiveController.
-    await dc.context.sendActivity(`We are waiting for a proactive message. ${this.notifyMessage(this.serverUrl, activity.from.id)}`);
+    await dc.context.sendActivity(`We are waiting for a proactive message. ${this.notifyMessage(activity.from.id)}`);
 
     return Dialog.EndOfTurn;
   }

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/sso/ssoSkillDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/sso/ssoSkillDialog.js
@@ -12,7 +12,7 @@ const SSO_SKILL_DIALOG = 'SsoSkillDialog';
 class SsoSkillDialog extends ComponentDialog {
   /**
    * @param {string} dialogId
-   * @param {Object} configuration
+   * @param {import('../../config').DefaultConfig} configuration
    */
   constructor (dialogId, configuration) {
     super(dialogId);

--- a/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
+++ b/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
@@ -49,10 +49,10 @@ namespace SkillFunctionalTests.ProactiveMessages
             var targetSkills = new List<string>
             {
                 SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
                 SkillBotNames.WaterfallSkillBotPython,
 
                 // TODO: Enable these when the ports to JS, and composer are ready
-                //SkillBotNames.WaterfallSkillBotJS,
                 //SkillBotNames.ComposerSkillBotDotNet
             };
 


### PR DESCRIPTION
Addresses # 503

## Description
This PR applies a workaround to a known issue with the `server.url` for the Restify server, showing `[::]` locally and `undefined:undefined` in Azure, causing the Proactive tests to not work properly, MessageWithAttachment and Cards Audio are also impacted.
This workaround simply gathers the url from the `WEBSITE_HOSTNAME` env variable when it's deployed in Azure, otherwise from the request headers.

> **Restify related issues:**
> server.url is wrong #1029 `https://github.com/restify/node-restify/issues/1029`
> server.url "undefined" on production server #1274 `https://github.com/restify/node-restify/issues/1274`

## Specific Changes
- Created a `config.js` file in charge of defining all the bot's configuration.
- Updated the following files to support the new configuration.
  - `activityRouterDialog.js`
  - `authDialog.js`
  - `cardDialog.js`
  - `messageWithAttachmentDialog.js` 
  - `skillBot.js`
  - `ssoSkillDialog.js`
  - `waitForProactiveDialog.js`
- Updated `index.js` to support the new  `DefaultConfig` class, and the server url assignation.
- Added `WaterfallSkillBotJS` in the `ProactiveTests.cs` test.

## Testing
The following images show the pipeline tests passing successfully and the url both locally and Azure.
![image](https://user-images.githubusercontent.com/62260472/143088322-49795874-7291-4e41-85f0-204b56aed892.png)
