### PR TITLE
[#503] JavaScript Bots - Replace Array with Set when looking at runtime

### DIFF
--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/dialogs/setupDialog.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/dialogs/setupDialog.js
@@ -35,11 +35,11 @@ class SetupDialog extends ComponentDialog {
   }
 
   /**
-     * The run method handles the incoming activity (in the form of a TurnContext) and passes it through the dialog system.
-     * If no dialog is active, it will start the default dialog.
-     * @param {*} turnContext
-     * @param {*} accessor
-     */
+   * The run method handles the incoming activity (in the form of a TurnContext) and passes it through the dialog system.
+   * If no dialog is active, it will start the default dialog.
+   * @param {*} turnContext
+   * @param {*} accessor
+   */
   async run (turnContext, accessor) {
     const dialogSet = new DialogSet(accessor);
     dialogSet.add(this);
@@ -52,8 +52,8 @@ class SetupDialog extends ComponentDialog {
   }
 
   /**
-     * Render a prompt to select the delivery mode to use.
-     */
+   * Render a prompt to select the delivery mode to use.
+   */
   async selectDeliveryModeStep (stepContext) {
     // Create the PromptOptions with the delivery modes supported.
     const messageText = 'What delivery mode would you like to use?';
@@ -69,8 +69,8 @@ class SetupDialog extends ComponentDialog {
   }
 
   /**
-     * Render a prompt to select the skill to call.
-     */
+   * Render a prompt to select the skill to call.
+   */
   async selectSkillStep (stepContext) {
     // Set delivery mode.
     this.deliveryMode = stepContext.result.value;
@@ -82,7 +82,7 @@ class SetupDialog extends ComponentDialog {
     const options = {
       prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
       retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
-      choices: Object.keys(this.skillsConfig.skills),
+      choices: [...this.skillsConfig.skills.ids],
       style: ListStyle.suggestedAction
     };
 
@@ -91,16 +91,16 @@ class SetupDialog extends ComponentDialog {
   }
 
   /**
-     * The SetupDialog has ended, we go back to the HostBot to connect with the selected skill.
-     */
+   * The SetupDialog has ended, we go back to the HostBot to connect with the selected skill.
+   */
   async finalStep (stepContext) {
-    const selectedSkill = this.skillsConfig.skills[stepContext.result.value];
-    const v3Bots = ['EchoSkillBotDotNetV3', 'EchoSkillBotJSV3'];
+    const selectedSkill = this.skillsConfig.skills.entries[stepContext.result.value];
+    const v3Bots = new Set(['EchoSkillBotDotNetV3', 'EchoSkillBotJSV3']);
 
     // Set active skill
     await this.activeSkillProperty.set(stepContext.context, selectedSkill);
 
-    if (this.deliveryMode === DeliveryModes.ExpectReplies && v3Bots.includes(selectedSkill.id)) {
+    if (this.deliveryMode === DeliveryModes.ExpectReplies && v3Bots.has(selectedSkill.id)) {
       const message = MessageFactory.text("V3 Bots do not support 'expectReplies' delivery mode.");
       await stepContext.context.sendActivity(message);
 

--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/index.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/index.js
@@ -66,11 +66,9 @@ const maxTotalSockets = (
     preallocatedSnatPorts
   );
 
-const allowedCallers = Object.values(skillsConfig.skills).map(skill => skill.appId);
-
 const authConfig = new AuthenticationConfiguration(
   [],
-  allowedCallersClaimsValidator(allowedCallers)
+  allowedCallersClaimsValidator([...skillsConfig.skills.appIds])
 );
 
 const credentialsFactory = new PasswordServiceClientCredentialFactory(

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/TokenExchangeSkillHandler.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/TokenExchangeSkillHandler.js
@@ -51,7 +51,7 @@ class TokenExchangeSkillHandler extends SkillHandler {
       return null;
     }
 
-    return Object.values(this.skillsConfig.skills).find(skill => skill.appId === appId);
+    return Object.values(this.skillsConfig.skills.entries).find(skill => skill.appId === appId);
   }
 
   async interceptOAuthCards (claimsIdentity, activity) {

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/dialogs/sso/ssoDialog.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/dialogs/sso/ssoDialog.js
@@ -55,24 +55,24 @@ class SsoDialog extends ComponentDialog {
    * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
    */
   async getPromptChoices (stepContext) {
-    const promptChoices = [];
+    const promptChoices = new Set();
     const adapter = stepContext.context.adapter;
     const token = await adapter.getUserToken(stepContext.context, this.connectionName);
 
     if (!token) {
-      promptChoices.push('Login');
+      promptChoices.add('Login');
       // Token exchange will fail when the host is not logged on and the skill should
       // show a regular OAuthPrompt.
-      promptChoices.push('Call Skill (without SSO)');
+      promptChoices.add('Call Skill (without SSO)');
     } else {
-      promptChoices.push('Logout');
-      promptChoices.push('Show token');
-      promptChoices.push('Call Skill (with SSO)');
+      promptChoices.add('Logout');
+      promptChoices.add('Show token');
+      promptChoices.add('Call Skill (with SSO)');
     }
 
-    promptChoices.push('Back');
+    promptChoices.add('Back');
 
-    return ChoiceFactory.toChoices(promptChoices);
+    return ChoiceFactory.toChoices([...promptChoices]);
   }
 
   /**

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/index.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/index.js
@@ -70,11 +70,9 @@ const maxTotalSockets = (
     preallocatedSnatPorts
   );
 
-const allowedCallers = Object.values(skillsConfig.skills).map(skill => skill.appId);
-
 const authConfig = new AuthenticationConfiguration(
   [],
-  allowedCallersClaimsValidator(allowedCallers)
+  allowedCallersClaimsValidator([...skillsConfig.skills.appIds])
 );
 
 const credentialsFactory = new PasswordServiceClientCredentialFactory(

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/skills/echoSkill.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/skills/echoSkill.js
@@ -4,20 +4,16 @@
 const { ActivityEx } = require('botbuilder-core');
 const { SkillDefinition } = require('./skillDefinition');
 
-const SkillAction = {
-  Message: 'Message'
-};
-
 class EchoSkill extends SkillDefinition {
   getActions () {
-    return Object.values(SkillAction);
+    return new Set(['Message']);
   }
 
   /**
    * @param {string} actionId
    */
   createBeginActivity (actionId) {
-    if (!this.getActions().includes(actionId)) {
+    if (!this.getActions().has(actionId)) {
       throw new Error(`[EchoSkill]: Unable to create begin activity for "${actionId}".`);
     }
 

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/skills/teamsSkill.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/skills/teamsSkill.js
@@ -4,31 +4,29 @@
 const { ActivityEx } = require('botbuilder-core');
 const { SkillDefinition } = require('./skillDefinition');
 
-const SkillAction = {
-  TeamsTaskModule: 'TeamsTaskModule',
-  TeamsCardAction: 'TeamsCardAction',
-  TeamsConversation: 'TeamsConversation',
-  Cards: 'Cards',
-  Proactive: 'Proactive',
-  Attachment: 'Attachment',
-  Auth: 'Auth',
-  Sso: 'Sso',
-  Echo: 'Echo',
-  FileUpload: 'FileUpload',
-  Delete: 'Delete',
-  Update: 'Update'
-};
-
 class TeamsSkill extends SkillDefinition {
   getActions () {
-    return Object.values(SkillAction);
+    return new Set([
+      'TeamsTaskModule',
+      'TeamsCardAction',
+      'TeamsConversation',
+      'Cards',
+      'Proactive',
+      'Attachment',
+      'Auth',
+      'Sso',
+      'Echo',
+      'FileUpload',
+      'Delete',
+      'Update'
+    ]);
   }
 
   /**
    * @param {string} actionId
    */
   createBeginActivity (actionId) {
-    if (!this.getActions().includes(actionId)) {
+    if (!this.getActions().has(actionId)) {
       throw new Error(`[TeamsSkill]: Unable to create begin activity for "${actionId}".`);
     }
 

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/skills/waterfallSkill.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/skills/waterfallSkill.js
@@ -4,28 +4,26 @@
 const { ActivityEx } = require('botbuilder-core');
 const { SkillDefinition } = require('./skillDefinition');
 
-const SkillAction = {
-  Cards: 'Cards',
-  Proactive: 'Proactive',
-  Auth: 'Auth',
-  MessageWithAttachment: 'MessageWithAttachment',
-  Sso: 'Sso',
-  FileUpload: 'FileUpload',
-  Echo: 'Echo',
-  Delete: 'Delete',
-  Update: 'Update'
-};
-
 class WaterfallSkill extends SkillDefinition {
   getActions () {
-    return Object.values(SkillAction);
+    return new Set([
+      'Cards',
+      'Proactive',
+      'Auth',
+      'MessageWithAttachment',
+      'Sso',
+      'FileUpload',
+      'Echo',
+      'Delete',
+      'Update'
+    ]);
   }
 
   /**
    * @param {string} actionId
    */
   createBeginActivity (actionId) {
-    if (!this.getActions().includes(actionId)) {
+    if (!this.getActions().has(actionId)) {
       throw new Error(`[WaterfallSkill]: Unable to create begin activity for "${actionId}".`);
     }
 

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/cardDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/cardDialog.js
@@ -5,7 +5,7 @@ const { InputHints, MessageFactory, CardFactory, ActionTypes } = require('botbui
 const { ComponentDialog, WaterfallDialog, ChoicePrompt, ListStyle, ChoiceFactory, DialogTurnStatus } = require('botbuilder-dialogs');
 const fs = require('fs');
 const path = require('path');
-const { CardOptions } = require('./cardOptions');
+const { CardOptions, CardOptionsNames } = require('./cardOptions');
 const { CardSampleHelper } = require('./cardSampleHelper');
 const { ChannelSupportedCards } = require('./channelSupportedCards');
 
@@ -68,7 +68,7 @@ class CardDialog extends ComponentDialog {
     const options = {
       prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
       retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
-      choices: ChoiceFactory.toChoices(Object.values(CardOptions)),
+      choices: ChoiceFactory.toChoices([...CardOptionsNames]),
       style: ListStyle.list
     };
 
@@ -85,7 +85,7 @@ class CardDialog extends ComponentDialog {
     } else {
       // Checks to see if the activity is an adaptive card update or a bot action respose.
       const card = stepContext.result.value;
-      const cardType = Object.keys(CardOptions).find(key => CardOptions[key].toLowerCase() === card.toLowerCase());
+      const cardType = CardOptions[card];
       const { channelId } = stepContext.context.activity;
 
       if (ChannelSupportedCards.isCardSupported(channelId, cardType)) {

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/cardOptions.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/cardOptions.js
@@ -67,3 +67,5 @@ module.exports.CardOptions = {
    */
   End: 'End'
 };
+
+module.exports.CardOptionsNames = new Set(Object.keys(this.CardOptions));

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/channelSupportedCards.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/cards/channelSupportedCards.js
@@ -8,22 +8,22 @@ const { CardOptions } = require('./cardOptions');
  * This tracks what cards are not supported in a given channel.
  */
 const unsupportedChannelCards = {
-  [Channels.Emulator]: [
+  [Channels.Emulator]: new Set([
     CardOptions.AdaptiveCardTeamsTaskModule,
     CardOptions.AdaptiveUpdate,
     CardOptions.TeamsFileConsent,
     CardOptions.O365
-  ],
-  [Channels.Directline]: [
+  ]),
+  [Channels.Directline]: new Set([
     CardOptions.AdaptiveUpdate
-  ],
-  [Channels.Telegram]: [
+  ]),
+  [Channels.Telegram]: new Set([
     CardOptions.AdaptiveCardBotAction,
     CardOptions.AdaptiveCardTeamsTaskModule,
     CardOptions.AdaptiveCardSubmitAction,
     CardOptions.List,
     CardOptions.TeamsFileConsent
-  ]
+  ])
 };
 
 class ChannelSupportedCards {
@@ -36,7 +36,7 @@ class ChannelSupportedCards {
   static isCardSupported (channel, type) {
     const unsupportedChannel = unsupportedChannelCards[channel];
     if (unsupportedChannel) {
-      return !unsupportedChannel.includes(type);
+      return !unsupportedChannel.has(type);
     }
 
     return true;

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/sso/ssoSkillDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/sso/ssoSkillDialog.js
@@ -40,7 +40,7 @@ class SsoSkillDialog extends ComponentDialog {
     return stepContext.prompt(ACTION_PROMPT, {
       prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
       retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
-      choices: ChoiceFactory.toChoices(await this.getPromptChoices(stepContext))
+      choices: await this.getPromptChoices(stepContext)
     });
   }
 
@@ -48,19 +48,19 @@ class SsoSkillDialog extends ComponentDialog {
    * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
    */
   async getPromptChoices (stepContext) {
-    const choices = [];
+    const choices = new Set();
     const token = await stepContext.context.adapter.getUserToken(stepContext.context, this.connectionName);
 
     if (!token) {
-      choices.push('Login');
+      choices.add('Login');
     } else {
-      choices.push('Logout');
-      choices.push('Show token');
+      choices.add('Logout');
+      choices.add('Show token');
     }
 
-    choices.push('End');
+    choices.add('End');
 
-    return choices;
+    return ChoiceFactory.toChoices([...choices]);
   }
 
   /**


### PR DESCRIPTION
Addresses # 503

## Description
This PR replaces the use of `Array` in favor of using the [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) object, to have unique values and easy runtime access.
Additionally, some parts of code have been refactored and polished.

## Specific Changes
- Added the use of `Set` for `WaterfallHostBotJS`, `WaterfallSkillBotJS` and `SimpleHostBotJS`.
- Updated the `SkillsConfiguration` class for `WaterfallHostBotJS` and `SimpleHostBotJS` to be similar between the hosts, and define a unique Set of AppIds and Ids to be used throughout the bot.

## Testing
The following images show the Deploy and Test Scenarios pipelines working as expected.
![image](https://user-images.githubusercontent.com/62260472/143298531-f520cd2c-aacf-4dcd-a048-921dfa077ed7.png)