### PR TITLE
[#503] Improvements for Bots, Pipelines and Tests - Skip unnecesary checkout steps

### DIFF
--- a/build/yaml/cleanupResources/cleanupResources.yml
+++ b/build/yaml/cleanupResources/cleanupResources.yml
@@ -39,6 +39,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - template: ../common/deleteResourceGroup.yml
           parameters:
             azureSubscription: $(AZURESUBSCRIPTION)
@@ -51,6 +52,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - template: ../common/deleteResourceGroup.yml
           parameters:
             azureSubscription: $(AZURESUBSCRIPTION)
@@ -63,6 +65,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - template: ../common/deleteResourceGroup.yml
           parameters:
             azureSubscription: $(AZURESUBSCRIPTION)
@@ -76,6 +79,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete App Service Plan (DotNet)"
           inputs:
@@ -100,6 +104,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete App Service Plan (JS)"
           inputs:
@@ -124,6 +129,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete App Service Plan (Python)"
           inputs:
@@ -150,6 +156,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete Virtual Network"
           inputs:
@@ -173,6 +180,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - template: deleteAppRegistrations.yml
           parameters:
             azureSubscription: "$(AZURESUBSCRIPTION)"
@@ -187,6 +195,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete Key Vault"
           inputs:
@@ -211,6 +220,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete App Insights"
           inputs:
@@ -240,6 +250,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete CosmosDB"
           inputs:
@@ -263,6 +274,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - task: AzureCLI@2
           displayName: "Delete Container Registry"
           inputs:
@@ -292,6 +304,7 @@ stages:
     - job: "Delete"
       displayName: "Delete steps"
       steps:
+        - checkout: none
         - template: ../common/deleteResourceGroup.yml
           parameters:
             azureSubscription: $(AZURESUBSCRIPTION)

--- a/build/yaml/deployBotResources/common/prepareResources.yml
+++ b/build/yaml/deployBotResources/common/prepareResources.yml
@@ -16,6 +16,7 @@ stages:
       - job: "Prepare"
         displayName: "Prepare steps"
         steps:
+          - checkout: none
           - template: ../../common/deleteResourceGroup.yml 
             parameters:
               azureSubscription: "${{ parameters.azureSubscription }}"

--- a/build/yaml/sharedResources/createSharedResources.yml
+++ b/build/yaml/sharedResources/createSharedResources.yml
@@ -86,6 +86,7 @@ stages:
     - job: Check_Key_Vault_Object_Id
       displayName: Check KeyVaultObjectId value
       steps:
+        - checkout: none
         - powershell: |
               $keyVaultObjectId = '$(INTERNALKEYVAULTOBJECTID)'
               if ($keyVaultObjectId -ne '') {
@@ -134,6 +135,7 @@ stages:
     - job: Check_App_Service_Plan_Creation
       displayName: "Check AppServicePlan Creation"
       steps:
+      - checkout: none
       - powershell: |
             $AppServicePlanDotNet = '$(INTERNALAPPSERVICEPLANDOTNETNAME)'
             $AppServicePlanJS = '$(INTERNALAPPSERVICEPLANJSNAME)'

--- a/build/yaml/testScenarios/runTestScenarios.yml
+++ b/build/yaml/testScenarios/runTestScenarios.yml
@@ -43,6 +43,7 @@ stages:
       - job: "Download_Variables"
         displayName: "Download Variables"
         steps:
+          - checkout: none
           - powershell: |
               $pipelineGuid = if ([string]::IsNullOrEmpty("$env:DEPLOYBOTRESOURCESGUID")) { "02 - Deploy Bot Resources" } else { "$(DEPLOYBOTRESOURCESGUID)" }
               Write-Host "Deploy Bot Resources Pipeline GUID: " $pipelineGuid


### PR DESCRIPTION
Addresses # 503

## Description
This PR adds `checkout: none` in several steps of the pipelines, to stop jobs that don't require having a copy of the repository from downloading it.

## Specific Changes
- Added `checkout: none` to:
  - The `Check KeyVaultObjectId value` and `Check AppServicePlan Creation` jobs within the [01 - Create Shared Resources](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/build/yaml/sharedResources) pipeline
  - The `Prepare` jobs within the [02.A - Deploy Bot Resources](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/build/yaml/deployBotResources) pipeline
  - The `Download Variables` job of the [02.B - Run Test Scenarios](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/build/yaml/testScenarios) pipeline
  - Jobs within the [04 - Cleanup Resources](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/build/yaml/cleanupResources) pipeline

## Testing

The following images show the before and after of the _02.A - Deploy Bot Resources_ pipeline.
![image](https://user-images.githubusercontent.com/44245136/143305412-849e156e-9d52-45cf-9c55-2a2848b4fab5.png)
