### PR TITLE
[#516] Dotnet pipelines are pulling 5.x daily instead of 4.x

### DIFF
--- a/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
@@ -17,57 +17,148 @@ steps:
     inputs:
       targetType: inline
       failOnStderr: true
+      pwsh: true
       script: |
-        # Get Source
-        $sourceDotNetv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-dotnet-daily/api/v3/index.json"
-        $sourceDotNetArtifacts = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json"
-        $sourceDotNetMyGet = "https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json"
-        $sourceDotNetNuGet = "https://api.nuget.org/v3/index.json"
+        $botType = "${{ parameters.botType }}";
+        $version = "${{ parameters.version }}";
+        $registry = "${{ parameters.registry }}";
 
-        switch -regex ("${{ parameters.registry }}") {
-          "^($null|)$" {
-            switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceDotNetv3MyGet }
-              default { $source = $sourceDotNetArtifacts }
-            }
-          }
-          "Artifacts" { $source = $sourceDotNetArtifacts }
-          "MyGet" { 
-            switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceDotNetv3MyGet }
-              default { $source = $sourceDotNetMyGet }
-            }
-          }
-          "NuGet" { $source = $sourceDotNetNuGet }
-          default { $source = "${{ parameters.registry }}" }
-        }
-        Write-Host "Source: $source"
+        Set-Variable ARTIFACTS -Option ReadOnly -Value "Artifacts"
+        Set-Variable MYGET -Option ReadOnly -Value "MyGet"
+        Set-Variable NUGET -Option ReadOnly -Value "NuGet"
+        Set-Variable CUSTOM -Option ReadOnly -Value "Custom"
 
-        # Get Version Number
-        $tags = ""
-        switch -regex ("${{ parameters.version }}") {
-          "^($null||LATEST||STABLE)$" {
-            if (("${{ parameters.version }}" -in "STABLE") -and ($source -match $sourceDotNetArtifacts)) {
-              [Console]::ForegroundColor = "red"
-              [Console]::Error.WriteLine("Stable versions of BotBuilder DotNet are not available for this source.")
-              [Console]::ResetColor()
-              exit 1 # Force exit
-            }
-            if("${{ parameters.version }}" -notin "STABLE") {
-              $tags = "-PreRelease"
-            }
-            if ("${{ parameters.botType }}" -in "Host", "Skill") {
-              $PackageList = nuget list "Microsoft.Bot.Builder" -Source "$source" "$tags" | Select-String -Pattern "^Microsoft.Bot.Builder "
-              $versionNumber = ($PackageList -split " ")[-1]
-            } elseif ("${{ parameters.botType }}" -in "SkillV3") {
-              $PackageList = nuget list "Microsoft.Bot.Builder.History" -Source "$source" "$tags" | Select-String -Pattern "^Microsoft.Bot.Builder.History"
-              $versionNumber = ($PackageList -split " ")[-1]
-            }
-          }
-          default { $versionNumber = "${{ parameters.version }}" }
+        $isPreRelease = $version -match "^($null||LATEST)$";
+        $isRelease = $version -match "^(STABLE)$";
+        $isCustomVersion = -not ($isPreRelease -or $isRelease);
+        $isSkillV3 = $botType -eq "SkillV3";
+        $isComposer = $botType -in "ComposerHost", "ComposerSkill";
+
+        function ExitWithError ($message) {
+          [Console]::ForegroundColor = "red"
+          [Console]::Error.WriteLine($message)
+          [Console]::ResetColor()
+          exit 1 # Force exit
         }
-        Write-Host "Version Number: $versionNumber"
+
+        $versions = @();
+        $filters = @{
+          query      = "";
+          library    = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+          version    = "^4.";
+          prerelease = [System.Convert]::ToString($isPreRelease).ToLower();
+        }
+
+        $result = @{
+          version = "";
+          source  = "";
+        }
+
+        # Empty Registry
+        if ($registry -match "^($null|)$") {
+          $registry = $isSkillV3 ? $MYGET : $ARTIFACTS;
+        }
+        # Artifacts
+        elseif ($registry -match "^($ARTIFACTS)$") {
+          $registry = $ARTIFACTS;
+        }
+        # MyGet
+        elseif ($registry -match "^($MYGET)$") {
+          $registry = $MYGET;
+        }
+        # NuGet
+        elseif ($registry -match "^($NUGET)$") {
+          $registry = $NUGET;
+        }
+        # Custom Registry
+        else {
+          $filters.query = $registry;
+          $filters.prerelease = $isPreRelease ? "-PreRelease" : "";
+          $registry = $CUSTOM;
+        }
+
+        if ($isRelease -and $registry -eq $ARTIFACTS) {
+          ExitWithError "Stable versions of BotBuilder DotNet are not available in $ARTIFACTS.";
+        }
+
+        if ($isComposer) {
+          $filters.library = "Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime";
+        }
+
+        if ($isSkillV3) {
+          $filters.version = "^3.";
+          $filters.library = "Microsoft.Bot.Builder.History";
+        }
+
+        if ($isCustomVersion) {
+          $filters.version = "^($version)$";
+        }
+
+
+        switch ($registry) {
+          $ARTIFACTS {
+            $result.source = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json";
+            $filters.query = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/packages?includeAllVersions=true&api-version=6.0-preview.1&packageNameQuery=$($filters.library)&`$top=1";
+            $data = Invoke-RestMethod -Uri $filters.query;
+            $versions = @($data.value[0].versions);
+          }
+          $MYGET {
+            $feed = $isSkillV3 ? "botbuilder-v3-dotnet-daily" : "botbuilder-v4-dotnet-daily";
+            $result.source = "https://botbuilder.myget.org/F/$($feed)/api/v3/index.json";
+            $filters.query = "https://botbuilder.myget.org/F/$($feed)/api/v3/query?q=packageid:$($filters.library)&prerelease=$($filters.prerelease)";
+            $data = Invoke-RestMethod -Uri $filters.query;
+            $versions = @($data.data[0].versions);
+            $versions = $versions[($versions.count - 1)..0];
+          }
+          $NUGET {
+            $result.source = "https://api.nuget.org/v3/index.json";
+            $filters.query = "https://azuresearch-usnc.nuget.org/query?q=packageid:$($filters.library)&prerelease=$($filters.prerelease)&semVerLevel=2.0.0";
+            $data = Invoke-RestMethod -Uri $filters.query;
+            $versions = @($data.data[0].versions);
+            $versions = $versions[($versions.count - 1)..0];
+          }
+          Default {
+            # Custom Registry
+            $result.source = $filters.query;
+            $data = nuget list $filters.library -Source $filters.query -AllVersions $filters.prerelease;
+            $versions = $data | ForEach-Object {
+              $lib, $ver = $_ -split " ";
+              return [PSCustomObject]@{ Package = $lib; Version = $ver };
+            } | Sort-Object -Descending { [regex]::Replace($_.Version, '\d+', { $args[0].Value.PadLeft(20) }) }
+          }
+        }
+
+        $result.version = @($versions | Select-Object -ExpandProperty version | Where-Object { $_ -match $filters.version } | Select-Object -First 1);
+
+        if ($isPreRelease) {
+          $label = "Latest";
+        }
+        elseif ($isRelease) {
+          $label = "Stable";
+        }
+        else {
+          $label = "Custom";
+        }
+
+        if (-not $result.version) {
+          $message = @"
+        Unable to find the Version in the selected Registry:
+          Version       : $version ($label)
+          Registry      : $registry
+          Source        : $($result.source)
+          Search Query  : $($filters.query)
+        "@;
+          ExitWithError $message
+        }
+
+        @"
+        Version & Registry to install the packages:
+          Version       : $($result.version) ($label)
+          Registry      : $registry
+          Source        : $($result.source)
+          Search Query  : $($filters.query)
+        "@
 
         # Set environment variables
-        Write-Host "##vso[task.setvariable variable=DependenciesSource]$source"
-        Write-Host "##vso[task.setvariable variable=DependenciesVersionNumber]$versionNumber"
+        Write-Host "##vso[task.setvariable variable=DependenciesSource]$($result.source)"
+        Write-Host "##vso[task.setvariable variable=DependenciesVersionNumber]$($result.version)"


### PR DESCRIPTION
Fixes # 516

## Description
This PR fixes an issue where the pipeline script in charge of gathering the `BotBuilder` version based on the `BotType, Registry and Version (Stable, Latest, Custom)` will obtain `5.x.x` versions instead of `4.x.x`.
Continue using the `nuget list` command by adding the `-AllVersions` flag will increase considerably the time it takes to gather all the versions of a package (`e.g. MyGet approx. 1 to 3 min`). Therefore, the fastest option was to use each registry API Rest (`e.g. MyGet approx. 1 to 3 sec`).

## Specific Changes
- Updated the `Evaluate source & version` task script to obtain `4.x.x` versions instead of `5.x.x`.
  - Script refactored to use each registry API Rest instead of the `nuget list` command to reduce considerably the execution time.
  - The structure has been cleaned up, improving its readability.
  - Improved script output by showing the `Version`, `Registry`, `Source` and the `Search Query` used to obtain the desired version.
  - Added new validation, that will fail when the version cannot be obtained from the selected Registry (when using Stable, Latest or Custom version).
  - When a Custom Registry is used, the script will continue using the `nuget list` command.

## Testing
The following images show the pipeline running successfully, and when the script success or fails to obtain the version in the registry.
![image](https://user-images.githubusercontent.com/62260472/146208210-6555d5f9-0151-4b47-b40f-4aa65d664e3d.png)