### PR TITLE
[#525] Update components to latest versions

### DIFF
--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/package.json
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/package.json
@@ -5,11 +5,16 @@
   "author": "Microsoft Corp.",
   "license": "MIT",
   "scripts": {
-    "start": "node ./index.js"
+    "start": "node ./index.js",
+    "postinstall": "rimraf -rf node_modules/botbuilder/node_modules/chrono-node"
   },
   "dependencies": {
     "botbuilder": "^3.30.0",
+    "chrono-node": "2.2.4",
     "dotenv": "^8.2.0",
     "restify": "^8.5.1"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2"
   }
 }

--- a/Bots/JavaScript/yarn.lock
+++ b/Bots/JavaScript/yarn.lock
@@ -1262,12 +1262,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrono-node@npm:^1.1.3":
-  version: 1.4.8
-  resolution: "chrono-node@npm:1.4.8"
+"chrono-node@npm:2.2.4, chrono-node@npm:^1.1.3":
+  version: 2.2.4
+  resolution: "chrono-node@npm:2.2.4"
   dependencies:
-    dayjs: ^1.8.19
-  checksum: 964b392813284c99df5b16757882e7164f4a11839020028eaa0e9960dc048f30887ad792ce308e20d531abf20a025b3a4d85812e55ccc8a70db0feef783ec84b
+    dayjs: ^1.10.0
+  checksum: ed5499bfcf40fcb69e212fbf0cbeaebd80397fcef259741d3ee1bf55920e72b89fab60833f4b6511e2f7646695d92bde566c9cc77cee5e8efc3a504345f4eeb7
   languageName: node
   linkType: hard
 
@@ -1485,7 +1485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.10.3, dayjs@npm:^1.8.19":
+"dayjs@npm:^1.10.0, dayjs@npm:^1.10.3":
   version: 1.10.7
   resolution: "dayjs@npm:1.10.7"
   checksum: a0a4ca95abaa03d0702161dc2c35d16121188e342f5052b9c61cdf784dab68af766f477c04f87f71c6af666fd4d13db9b9853b87265850d6093b7b04e1bb1cd7
@@ -5516,8 +5516,10 @@ fsevents@~2.3.2:
   resolution: "v3-skill-bot@workspace:Skills/CodeFirst/EchoSkillBot-v3"
   dependencies:
     botbuilder: ^3.30.0
+    chrono-node: 2.2.4
     dotenv: ^8.2.0
     restify: ^8.5.1
+    rimraf: ^3.0.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes # 525

> **Note:** Regarding Python's babel dependency, has been already addressed in the PR botbuilder-python # 1826.

## Description
This PR updates the `chrono-node` version for the JavaScript `EchoSkillBot-v3` bot, by forcing the new `2.2.4` version and removing the `1.4.8` after the installation completes. Moreover, the `yarn.lock` has been updated to resolve to the new `2.2.4` version as well.

### Detailed Changes
- Added the `chrono-node@2.2.4` dependency for the JavaScript `EchoSkillBot-v3` bot, and added the `postinstall` script to remove the `1.4.8` one after the installation finishes.
- Updated the `yarn.lock` file to resolve the `chrono-node@1.4.8` dependency to the new `2.2.4` version.

## Testing
The following images show the Deploy and Test Scenarios pipelines working, and the downloaded bot's source code from the Deploy pipeline, with the `chrono-node` version being forced. 
![imagen](https://user-images.githubusercontent.com/62260472/146830063-2d9be57d-ed6b-4855-a8d4-ee89d42367a0.png)