### PR TITLE
[#517] Fix issues running deploy pipeline in botframework-functionalTest js

### DIFF
--- a/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
@@ -22,23 +22,29 @@ steps:
         $sourceJSMyGet = "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
         $sourceJSv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-js-daily/npm/"
         $sourceJSNpm = "https://registry.npmjs.com/"
-        switch -regex ("${{ parameters.registry }}") {
+        $versionNumber = "${{ parameters.version }}"
+        $registry = "${{ parameters.registry }}"
+        $botType =  "${{ parameters.botType }}"
+        switch -regex ($registry) {
           "^($null|MyGet)$" {
-            switch ("${{ parameters.botType }}") {
+            switch ($botType) {
               "SkillV3" { $source = $sourceJSv3MyGet }
               default { $source = $sourceJSMyGet }
             }
           }
-          "Npm" { $source = $sourceJSNpm }
-          default { $source = "${{ parameters.registry }}" }
+          "Npm" { $source = $sourceJSNpm 
+            if ([string]::IsNullOrEmpty($versionNumber)){
+              $versionNumber = "STABLE"
+            }
+          }
+          default { $source = $registry }
         }
-        Write-Host "Source: $source"
         npm config set registry $source
 
         # Get Version Number
-        switch -regex ("${{ parameters.version }}") {
+        switch -regex ("$versionNumber") {
           "^($null||LATEST)$" {
-            if ("${{ parameters.botType }}" -in "SkillV3") {
+            if ($botType -in "SkillV3") {
               if ($source -eq $sourceJSv3MyGet) {
                 $versionNumber = npm show botbuilder@latest version | Out-String
               } else {
@@ -49,18 +55,16 @@ steps:
             }
           }
           STABLE {
-            if ("${{ parameters.botType }}" -in "Host", "Skill") {
+            if ($botType -in "Host", "Skill") {
               $PackageList = npm show botbuilder@* version | Out-String;
             }
-            elseif ("${{ parameters.botType }}" -in "SkillV3") {
+            elseif ($botType -in "SkillV3") {
               $PackageList = npm show botbuilder@3.* version | Out-String;
             }
             $versionNumber = ($PackageList.Split(" ")[-1]).Trim().TrimStart("'").TrimEnd("'");
           }
-          default { $versionNumber = "${{ parameters.version }}" }
         }
-        Write-Host "Version Number: $versionNumber"
-        
+ 
         # Set environment variables
         Write-Host "##vso[task.setvariable variable=DependenciesSource]$source"
         Write-Host "##vso[task.setvariable variable=DependenciesVersionNumber]$versionNumber"

--- a/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
@@ -32,13 +32,15 @@ steps:
               default { $source = $sourceJSMyGet }
             }
           }
-          "Npm" { $source = $sourceJSNpm 
+          "Npm" { 
+            $source = $sourceJSNpm 
             if ([string]::IsNullOrEmpty($versionNumber)){
               $versionNumber = "STABLE"
             }
           }
           default { $source = $registry }
         }
+        Write-Host "Source: $source"
         npm config set registry $source
 
         # Get Version Number
@@ -64,6 +66,7 @@ steps:
             $versionNumber = ($PackageList.Split(" ")[-1]).Trim().TrimStart("'").TrimEnd("'");
           }
         }
+        Write-Host "Version Number: $versionNumber"
  
         # Set environment variables
         Write-Host "##vso[task.setvariable variable=DependenciesSource]$source"


### PR DESCRIPTION
Addresses # 517
#minor
## Description
When deploying the bots using the pipeline from the file [deploybotresources.yml](https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/build/yaml/deployBotResources/deployBotResources.yml) using default values for version (null) and feed (npm) the tags created showed the preview version instead of the latest stable version. In this case the issue was located in the [evaluateDependenciesVariables.yml](https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml) as the code was following a wrong path for this case and retrieving the version using `next` command instead of `latest`.

## Specific Changes

- We added logic to check if the npm version is null or empty(the default case) we will follow the behavior for the stable version.

- We added intermediate variables storing the parameter for an easier way of testing.

## Testing
Local test on powershell
![image](https://user-images.githubusercontent.com/94375175/148117064-01089ca6-54f6-4c6d-b667-921664b1820f.png)
Pipeline running
![image](https://user-images.githubusercontent.com/94375175/148117137-218fef42-9b9b-4135-9185-d76c3ce36644.png)
Test pipeline
![image](https://user-images.githubusercontent.com/94375175/148117210-94a9844c-e1de-442b-9d62-56dbea9b7324.png)


