### PR TITLE
[#517] Issues running RC check against R15 branch - Pipeline Trigger 4.11

### DIFF
--- a/build/yaml/testScenarios/runTestScenarios.yml
+++ b/build/yaml/testScenarios/runTestScenarios.yml
@@ -7,6 +7,16 @@ name: $(BUILD.BUILDID)
 trigger: none
 pr: none
 
+resources:
+  pipelines:
+  - pipeline: "02ADeploySkillBots"
+    source: "02.A. Deploy skill bots (daily)"
+    trigger:
+      branches:
+        include:
+        - main
+        - releases/*
+
 variables:
   BuildConfiguration: "Debug"
 
@@ -44,7 +54,7 @@ stages:
         displayName: "Download Variables"
         steps:
           - powershell: |
-              $pipelineGuid = if ([string]::IsNullOrEmpty("$env:DEPLOYBOTRESOURCESGUID")) { "02 - Deploy Bot Resources" } else { "$(DEPLOYBOTRESOURCESGUID)" }
+              $pipelineGuid = if ([string]::IsNullOrEmpty("$env:DEPLOYBOTRESOURCESGUID")) { "02.A. Deploy skill bots (daily)" } else { "$(DEPLOYBOTRESOURCESGUID)" }
               Write-Host "Deploy Bot Resources Pipeline GUID: " $pipelineGuid
               Write-Host "##vso[task.setvariable variable=PipelineGuid]$pipelineGuid"
             displayName: "Set Deploy Bot Resources GUID"


### PR DESCRIPTION
Addresses # 517

## Description
This PR adds a pipeline trigger to concatenate the execution of the **02.A. Deploy skill bots** and **02.B. Run skill test scenarios** pipelines in _main_ and _releases_ branches.

### Detailed Changes
- Updated the `runTestScenarios` yaml adding configuration for a pipeline trigger.
- Updated the default value for the `DEPLOYBOTRESOURCESGUID` variable to match the current pipeline name.

## Testing
These images show the _02.B_ pipeline successfully triggered after the _02.A_ finishes its execution, both in _main_ and in one of the _releases_ branches.
![image](https://user-images.githubusercontent.com/44245136/148231532-7e8dd48c-05a6-406b-a45b-a317ccaca566.png)