### PR TITLE
[#465] Create composer version of WaterfallSkillBotDotNet - Fix FileUpload dialog

### DIFF
--- a/Bots/DotNet/Skills/Composer/ComposerSkillBotDotNet/ComposerSkillBotDotNet/dialogs/FileUploadDialog/language-generation/en-us/FileUploadDialog.en-us.lg
+++ b/Bots/DotNet/Skills/Composer/ComposerSkillBotDotNet/ComposerSkillBotDotNet/dialogs/FileUploadDialog/language-generation/en-us/FileUploadDialog.en-us.lg
@@ -6,7 +6,7 @@
 ]
 
 # AttachmentInput_Prompt_JKtU0T_text()
-- Please upload a file to continue
+- Please upload a file to continue.
 # AttachmentInput_UnrecognizedPrompt_JKtU0T()
 [Activity
     Text = ${AttachmentInput_UnrecognizedPrompt_JKtU0T_text()}


### PR DESCRIPTION
#minor

## Description
This PR fixes the text in the FileUpload dialog of ComposerSkillBotDotNet to avoid the tests to fail.

### Detailed Changes
- Added a missing period in `FileUploadDialog.en-us.lg` to match the text with the rest of the bots.

## Testing
This image shows the FileUpload scenario with all its tests passing.
![image](https://user-images.githubusercontent.com/44245136/151856091-3174a03b-743f-4228-aff5-9edfcf8cf626.png)
