### PR TITLE
[#554] Update source code namespaces - Libraries

### DIFF
--- a/Libraries/TranscriptConverter/ConvertTranscriptHandler.cs
+++ b/Libraries/TranscriptConverter/ConvertTranscriptHandler.cs
@@ -7,7 +7,7 @@ using System.CommandLine.Invocation;
 using System.IO;
 using Newtonsoft.Json;
 
-namespace TranscriptConverter
+namespace Microsoft.Bot.Builder.Testing.TranscriptConverter
 {
     public class ConvertTranscriptHandler
     {

--- a/Libraries/TranscriptConverter/Converter.cs
+++ b/Libraries/TranscriptConverter/Converter.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace TranscriptConverter
+namespace Microsoft.Bot.Builder.Testing.TranscriptConverter
 {
     public static class Converter
     {

--- a/Libraries/TranscriptConverter/Program.cs
+++ b/Libraries/TranscriptConverter/Program.cs
@@ -4,7 +4,7 @@
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 
-namespace TranscriptConverter
+namespace Microsoft.Bot.Builder.Testing.TranscriptConverter
 {
     public class Program
     {

--- a/Libraries/TranscriptConverter/TestScript.cs
+++ b/Libraries/TranscriptConverter/TestScript.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace TranscriptConverter
+namespace Microsoft.Bot.Builder.Testing.TranscriptConverter
 {
     /// <summary>
     /// A Test Script that can be used for functional testing of bots.

--- a/Libraries/TranscriptConverter/TestScriptItem.cs
+++ b/Libraries/TranscriptConverter/TestScriptItem.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace TranscriptConverter
+namespace Microsoft.Bot.Builder.Testing.TranscriptConverter
 {
     /// <summary>
     /// TestRunner's representation of an activity.

--- a/Libraries/TranscriptTestRunner.Tests/TestRunnerTests.cs
+++ b/Libraries/TranscriptTestRunner.Tests/TestRunnerTests.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 
 using Moq;
-using TranscriptTestRunner;
 using Xunit;
 
-namespace TranscriptTestRunner.Tests
+namespace Microsoft.Bot.Builder.Testing.TestRunner.Tests
 {
     public class TestRunnerTests
     {

--- a/Libraries/TranscriptTestRunner/Authentication/Session.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/Session.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json;
 
-namespace TranscriptTestRunner.Authentication
+namespace Microsoft.Bot.Builder.Testing.TestRunner.Authentication
 {
     /// <summary>
     /// Session definition.

--- a/Libraries/TranscriptTestRunner/Authentication/SessionInfo.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/SessionInfo.cs
@@ -3,7 +3,7 @@
 
 using System.Net;
 
-namespace TranscriptTestRunner.Authentication
+namespace Microsoft.Bot.Builder.Testing.TestRunner.Authentication
 {
     /// <summary>
     /// Session information definition.

--- a/Libraries/TranscriptTestRunner/Authentication/TestClientAuthentication.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/TestClientAuthentication.cs
@@ -10,7 +10,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
-namespace TranscriptTestRunner.Authentication
+namespace Microsoft.Bot.Builder.Testing.TestRunner.Authentication
 {
     /// <summary>
     /// Authentication class for the Test Client.

--- a/Libraries/TranscriptTestRunner/Authentication/TokenInfo.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/TokenInfo.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json;
 
-namespace TranscriptTestRunner.Authentication
+namespace Microsoft.Bot.Builder.Testing.TestRunner.Authentication
 {
     /// <summary>
     /// Token definition.

--- a/Libraries/TranscriptTestRunner/TestClientBase.cs
+++ b/Libraries/TranscriptTestRunner/TestClientBase.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 
-namespace TranscriptTestRunner
+namespace Microsoft.Bot.Builder.Testing.TestRunner
 {
     /// <summary>
     /// Base class for test clients.

--- a/Libraries/TranscriptTestRunner/TestClientFactory.cs
+++ b/Libraries/TranscriptTestRunner/TestClientFactory.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.ComponentModel;
+using Microsoft.Bot.Builder.Testing.TestRunner.TestClients;
 using Microsoft.Bot.Connector;
 using Microsoft.Extensions.Logging;
-using TranscriptTestRunner.TestClients;
 
-namespace TranscriptTestRunner
+namespace Microsoft.Bot.Builder.Testing.TestRunner
 {
     /// <summary>
     /// Factory class to create instances of <see cref="TestClientBase"/>.

--- a/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
+++ b/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
@@ -12,13 +12,13 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Testing.TestRunner.Authentication;
 using Microsoft.Bot.Connector.DirectLine;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest.TransientFaultHandling;
 using Newtonsoft.Json;
-using TranscriptTestRunner.Authentication;
 using Activity = Microsoft.Bot.Connector.DirectLine.Activity;
 using ActivityTypes = Microsoft.Bot.Schema.ActivityTypes;
 using Attachment = Microsoft.Bot.Connector.DirectLine.Attachment;
@@ -26,7 +26,7 @@ using BotActivity = Microsoft.Bot.Schema.Activity;
 using BotChannelAccount = Microsoft.Bot.Schema.ChannelAccount;
 using ChannelAccount = Microsoft.Bot.Connector.DirectLine.ChannelAccount;
 
-namespace TranscriptTestRunner.TestClients
+namespace Microsoft.Bot.Builder.Testing.TestRunner.TestClients
 {
     /// <summary>
     /// DirectLine implementation of <see cref="TestClientBase"/>.

--- a/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClientOptions.cs
+++ b/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClientOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace TranscriptTestRunner.TestClients
+namespace Microsoft.Bot.Builder.Testing.TestRunner.TestClients
 {
     /// <summary>
     /// Class with the options needed to run a test against a TesClient.

--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -18,12 +18,15 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
 using Activity = Microsoft.Bot.Schema.Activity;
 
-namespace TranscriptTestRunner
+namespace Microsoft.Bot.Builder.Testing.TestRunner
 {
     /// <summary>
     /// Test runner implementation.
     /// </summary>
+
+#pragma warning disable CA1724 // Type names should not match namespaces
     public class TestRunner
+#pragma warning restore CA1724 // Type names should not match namespaces
     {
         private readonly ILogger _logger;
         private readonly int _replyTimeout;

--- a/Libraries/TranscriptTestRunner/TestScript.cs
+++ b/Libraries/TranscriptTestRunner/TestScript.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace TranscriptTestRunner
+namespace Microsoft.Bot.Builder.Testing.TestRunner
 {
     /// <summary>
     /// A Test Script that can be used for functional testing of bots.

--- a/Libraries/TranscriptTestRunner/TestScriptItem.cs
+++ b/Libraries/TranscriptTestRunner/TestScriptItem.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace TranscriptTestRunner
+namespace Microsoft.Bot.Builder.Testing.TestRunner
 {
     /// <summary>
     /// <see cref="TestRunner"/> representation of an activity.

--- a/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
+++ b/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace TranscriptTestRunner.XUnit
+namespace Microsoft.Bot.Builder.Testing.TestRunner.XUnit
 {
     /// <summary>
     /// XUnit extension of <see cref="TestRunner"/>.


### PR DESCRIPTION
Addresses # 554

## Description
This PR updates the namespaces in the libraries' projects to be aligned with the Bot Framework namespaces.

### Detailed description
- Updated namespaces in _Microsoft.Bot.Builder.Testing.TranscriptConverter_'s classes.
- Updated namespaces in _Microsoft.Bot.Builder.Testing.TestRunner_'s classes.
- Added exclusion for rule CA1724 (Type names should not match namespaces) to TestRunner class.

## Testing
These images show the pipelines running after the changes.
![image](https://user-images.githubusercontent.com/44245136/156376330-914bcb00-9718-4e28-b2c4-31589a601681.png)