### PR TITLE
[#554] Update source code namespaces - Bots projects (2/3)

### DIFF
--- a/Bots/DotNet/ComposerSkillBotDotNet/Controllers/BotController.cs
+++ b/Bots/DotNet/ComposerSkillBotDotNet/Controllers/BotController.cs
@@ -1,15 +1,14 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace ComposerSkillBotDotNet.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.ComposerSkillBotDotNet.Controllers
 {
     // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be

--- a/Bots/DotNet/ComposerSkillBotDotNet/Controllers/SkillController.cs
+++ b/Bots/DotNet/ComposerSkillBotDotNet/Controllers/SkillController.cs
@@ -1,12 +1,11 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 
-namespace ComposerSkillBotDotNet.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.ComposerSkillBotDotNet.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.

--- a/Bots/DotNet/ComposerSkillBotDotNet/Program.cs
+++ b/Bots/DotNet/ComposerSkillBotDotNet/Program.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ComposerSkillBotDotNet
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.ComposerSkillBotDotNet
 {
     public class Program
     {

--- a/Bots/DotNet/ComposerSkillBotDotNet/Startup.cs
+++ b/Bots/DotNet/ComposerSkillBotDotNet/Startup.cs
@@ -1,15 +1,13 @@
-﻿using System.Collections.Concurrent;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.StaticFiles;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace ComposerSkillBotDotNet
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.ComposerSkillBotDotNet
 {
     public class Startup
     {

--- a/Bots/DotNet/EchoSkillBot-v3/ApiControllerActionInvokerWithErrorHandler.cs
+++ b/Bots/DotNet/EchoSkillBot-v3/ApiControllerActionInvokerWithErrorHandler.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http.Controllers;
 
-namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3
 {
     /// <summary>
     /// Web Api Controller to intersect HTTP operations when the Action Invoker is triggered to capture exceptions and send it to the bot as an Activity.

--- a/Bots/DotNet/EchoSkillBot-v3/App_Start/WebApiConfig.cs
+++ b/Bots/DotNet/EchoSkillBot-v3/App_Start/WebApiConfig.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Serialization;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 
-namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3
 {
     public static class WebApiConfig
     {

--- a/Bots/DotNet/EchoSkillBot-v3/Authentication/CustomAllowedCallersClaimsValidator.cs
+++ b/Bots/DotNet/EchoSkillBot-v3/Authentication/CustomAllowedCallersClaimsValidator.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
-namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3.Authentication
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3.Authentication
 {
     /// <summary>
     /// Sample claims validator that loads an allowed list from configuration if present

--- a/Bots/DotNet/EchoSkillBot-v3/Authentication/CustomSkillAuthenticationConfiguration.cs
+++ b/Bots/DotNet/EchoSkillBot-v3/Authentication/CustomSkillAuthenticationConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Bot.Connector.SkillAuthentication;
 using System.Configuration;
 using System.Linq;
 
-namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3.Authentication
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3.Authentication
 {
     public class CustomSkillAuthenticationConfiguration : AuthenticationConfiguration
     {

--- a/Bots/DotNet/EchoSkillBot-v3/Controllers/MessagesController.cs
+++ b/Bots/DotNet/EchoSkillBot-v3/Controllers/MessagesController.cs
@@ -10,11 +10,11 @@ using System.Web.Http;
 using Autofac;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Internals;
+using Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3.Authentication;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.SkillAuthentication;
-using Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3.Authentication;
 
-namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3
 {
     // Specify which type provides the authentication configuration to allow for validation for skills.
     [SkillBotAuthentication(AuthenticationConfigurationProviderType = typeof(CustomSkillAuthenticationConfiguration))]

--- a/Bots/DotNet/EchoSkillBot-v3/Dialogs/RootDialog.cs
+++ b/Bots/DotNet/EchoSkillBot-v3/Dialogs/RootDialog.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
 
-namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3.Dialogs
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3.Dialogs
 {
     [Serializable]
     public class RootDialog : IDialog<object>

--- a/Bots/DotNet/EchoSkillBot-v3/Global.asax
+++ b/Bots/DotNet/EchoSkillBot-v3/Global.asax
@@ -1,1 +1,1 @@
-﻿<%@ Application Codebehind="Global.asax.cs" Inherits="Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3.WebApiApplication" Language="C#" %>
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3.WebApiApplication" Language="C#" %>

--- a/Bots/DotNet/EchoSkillBot-v3/Global.asax.cs
+++ b/Bots/DotNet/EchoSkillBot-v3/Global.asax.cs
@@ -9,7 +9,7 @@ using Autofac;
 using Microsoft.Bot.Connector;
 using System.Reflection;
 
-namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBotv3
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotv3
 {
     public class WebApiApplication : System.Web.HttpApplication
     {

--- a/Bots/DotNet/EchoSkillBotComposer/Controllers/BotController.cs
+++ b/Bots/DotNet/EchoSkillBotComposer/Controllers/BotController.cs
@@ -1,15 +1,14 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace EchoSkillBotComposer.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotComposer.Controllers
 {
     // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be

--- a/Bots/DotNet/EchoSkillBotComposer/Controllers/SkillController.cs
+++ b/Bots/DotNet/EchoSkillBotComposer/Controllers/SkillController.cs
@@ -1,12 +1,11 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 
-namespace EchoSkillBotComposer.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotComposer.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.

--- a/Bots/DotNet/EchoSkillBotComposer/Program.cs
+++ b/Bots/DotNet/EchoSkillBotComposer/Program.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace EchoSkillBotComposer
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotComposer
 {
     public class Program
     {

--- a/Bots/DotNet/EchoSkillBotComposer/Startup.cs
+++ b/Bots/DotNet/EchoSkillBotComposer/Startup.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace EchoSkillBotComposer
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotComposer
 {
     public class Startup
     {

--- a/Bots/DotNet/SimpleHostBotComposer/Controllers/BotController.cs
+++ b/Bots/DotNet/SimpleHostBotComposer/Controllers/BotController.cs
@@ -1,15 +1,14 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace SimpleHostBotComposer.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.SimpleHostBotComposer.Controllers
 {
     // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be

--- a/Bots/DotNet/SimpleHostBotComposer/Controllers/SkillController.cs
+++ b/Bots/DotNet/SimpleHostBotComposer/Controllers/SkillController.cs
@@ -1,12 +1,11 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 
-namespace SimpleHostBotComposer.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.SimpleHostBotComposer.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.

--- a/Bots/DotNet/SimpleHostBotComposer/Program.cs
+++ b/Bots/DotNet/SimpleHostBotComposer/Program.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace SimpleHostBotComposer
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.SimpleHostBotComposer
 {
     public class Program
     {

--- a/Bots/DotNet/SimpleHostBotComposer/Startup.cs
+++ b/Bots/DotNet/SimpleHostBotComposer/Startup.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace SimpleHostBotComposer
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.SimpleHostBotComposer
 {
     public class Startup
     {


### PR DESCRIPTION
Addresses # 554

## Description
This PR updates the namespaces in the bots' classes to be aligned with the Bot Framework namespaces.

### Detailed description
- Updated namespaces in the classes of the following bots:
   - ComposerSkillBotDotNet
   - EchoSkillBot-v3
   - EchoSkillBotComposer
   - SimpleHostBotComposer
- Reordered using statements and removed the unnecessary ones.

## Testing
These images show the pipelines running after the changes.
![image](https://user-images.githubusercontent.com/44245136/156376330-914bcb00-9718-4e28-b2c4-31589a601681.png)