### PR TITLE
[#554] Update source code namespaces - Bots projects (3/3)

### DIFF
--- a/Bots/DotNet/WaterfallHostBot/AdapterWithErrorHandler.cs
+++ b/Bots/DotNet/WaterfallHostBot/AdapterWithErrorHandler.cs
@@ -4,19 +4,18 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Dialogs;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Middleware;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Middleware;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {

--- a/Bots/DotNet/WaterfallHostBot/Bots/RootBot.cs
+++ b/Bots/DotNet/WaterfallHostBot/Bots/RootBot.cs
@@ -5,12 +5,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Bots
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Bots
 {
     public class RootBot<T> : ActivityHandler
         where T : Dialog

--- a/Bots/DotNet/WaterfallHostBot/ComponentSettings.cs
+++ b/Bots/DotNet/WaterfallHostBot/ComponentSettings.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot
 {
     internal class ComponentSettings
     {

--- a/Bots/DotNet/WaterfallHostBot/Controllers/BotController.cs
+++ b/Bots/DotNet/WaterfallHostBot/Controllers/BotController.cs
@@ -4,11 +4,10 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Controllers
 {
     // This ASP Controller is created to handle a request. Dependency injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be

--- a/Bots/DotNet/WaterfallHostBot/Controllers/SkillController.cs
+++ b/Bots/DotNet/WaterfallHostBot/Controllers/SkillController.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.

--- a/Bots/DotNet/WaterfallHostBot/Dialogs/MainDialog.cs
+++ b/Bots/DotNet/WaterfallHostBot/Dialogs/MainDialog.cs
@@ -6,19 +6,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Dialogs.Sso;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Skills;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Dialogs
 {
     /// <summary>
     /// The main dialog for this bot. It uses a <see cref="SkillDialog"/> to call skills.

--- a/Bots/DotNet/WaterfallHostBot/Dialogs/Sso/SsoDialog.cs
+++ b/Bots/DotNet/WaterfallHostBot/Dialogs/Sso/SsoDialog.cs
@@ -5,13 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Dialogs.Sso
 {
     /// <summary>
     /// Helps prepare the host for SSO operations and provides helpers to check the status and invoke the skill.

--- a/Bots/DotNet/WaterfallHostBot/Dialogs/Sso/SsoSignInDialog.cs
+++ b/Bots/DotNet/WaterfallHostBot/Dialogs/Sso/SsoSignInDialog.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Dialogs.Sso
 {
     public class SsoSignInDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallHostBot/Dialogs/TangentDialog.cs
+++ b/Bots/DotNet/WaterfallHostBot/Dialogs/TangentDialog.cs
@@ -3,11 +3,10 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Dialogs
 {
     /// <summary>
     /// A simple waterfall dialog used to test triggering tangents from <see cref="MainDialog"/>.

--- a/Bots/DotNet/WaterfallHostBot/Middleware/LoggerMiddleware.cs
+++ b/Bots/DotNet/WaterfallHostBot/Middleware/LoggerMiddleware.cs
@@ -5,12 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Middleware
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Middleware
 {
     /// <summary>
     /// Uses an ILogger instance to log user and bot messages. It filters out ContinueConversation events coming from skill responses.

--- a/Bots/DotNet/WaterfallHostBot/Program.cs
+++ b/Bots/DotNet/WaterfallHostBot/Program.cs
@@ -4,7 +4,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot
 {
     public class Program
     {

--- a/Bots/DotNet/WaterfallHostBot/Skills/EchoSkill.cs
+++ b/Bots/DotNet/WaterfallHostBot/Skills/EchoSkill.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Skills
 {
     public class EchoSkill : SkillDefinition
     {

--- a/Bots/DotNet/WaterfallHostBot/Skills/SkillDefinition.cs
+++ b/Bots/DotNet/WaterfallHostBot/Skills/SkillDefinition.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Skills
 {
     /// <summary>
     /// Extends <see cref="BotFrameworkSkill"/> and provides methods to return the actions and the begin activity to start a skill.

--- a/Bots/DotNet/WaterfallHostBot/Skills/TeamsSkill.cs
+++ b/Bots/DotNet/WaterfallHostBot/Skills/TeamsSkill.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Skills
 {
     public class TeamsSkill : SkillDefinition
     {

--- a/Bots/DotNet/WaterfallHostBot/Skills/WaterfallSkill.cs
+++ b/Bots/DotNet/WaterfallHostBot/Skills/WaterfallSkill.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Skills
 {
     public class WaterfallSkill : SkillDefinition
     {

--- a/Bots/DotNet/WaterfallHostBot/SkillsConfiguration.cs
+++ b/Bots/DotNet/WaterfallHostBot/SkillsConfiguration.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Skills;
 using Microsoft.Extensions.Configuration;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot
 {
     /// <summary>
     /// A helper class that loads Skills information from configuration.

--- a/Bots/DotNet/WaterfallHostBot/Startup.cs
+++ b/Bots/DotNet/WaterfallHostBot/Startup.cs
@@ -4,20 +4,18 @@
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Bots;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.Dialogs;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Bots;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot
 {
     public class Startup
     {

--- a/Bots/DotNet/WaterfallHostBot/TokenExchangeSkillHandler.cs
+++ b/Bots/DotNet/WaterfallHostBot/TokenExchangeSkillHandler.cs
@@ -8,7 +8,6 @@ using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -16,7 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot
 {
     /// <summary>
     /// A <see cref="SkillHandler"/> specialized to support SSO Token exchanges.

--- a/Bots/DotNet/WaterfallSkillBot/Bots/SkillBot.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Bots/SkillBot.cs
@@ -6,11 +6,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Bots
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Bots
 {
     public class SkillBot<T> : ActivityHandler
         where T : Dialog

--- a/Bots/DotNet/WaterfallSkillBot/Controllers/BotController.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Controllers/BotController.cs
@@ -4,11 +4,10 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Controllers
 {
     // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be

--- a/Bots/DotNet/WaterfallSkillBot/Controllers/CardsController.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Controllers/CardsController.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Controllers
 {
     // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be

--- a/Bots/DotNet/WaterfallSkillBot/Controllers/ProactiveController.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Controllers/ProactiveController.cs
@@ -8,13 +8,12 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Proactive;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proactive;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Controllers
 {
     [Route("api/notify")]
     [ApiController]

--- a/Bots/DotNet/WaterfallSkillBot/Controllers/SkillController.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Controllers/SkillController.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Controllers
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
@@ -6,25 +6,24 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Auth;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Cards;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Delete;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.FileUpload;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.MessageWithAttachment;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Proactive;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Sso;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Update;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Auth;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Cards;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Delete;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.FileUpload;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.MessageWithAttachment;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proactive;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Sso;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Update;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs
 {
     /// <summary>
     /// A root dialog that can route activities sent to the skill to different sub-dialogs.

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Auth/AuthDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Auth/AuthDialog.cs
@@ -3,12 +3,11 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Auth
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Auth
 {
     public class AuthDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/AdaptiveCardExtensions.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/AdaptiveCardExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Cards
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Cards
 {
     public static class AdaptiveCardExtensions
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/CardDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/CardDialog.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveCards;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
@@ -17,7 +16,7 @@ using Microsoft.Bot.Schema.Teams;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Cards
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Cards
 {
     public class CardDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/CardOptions.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/CardOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Cards
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Cards
 {
     public enum CardOptions
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/CardSampleHelper.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/CardSampleHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Cards
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Cards
 {
     public static class CardSampleHelper
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/ChannelSupportedCards.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/ChannelSupportedCards.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.Bot.Connector;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Cards
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Cards
 {
     public static class ChannelSupportedCards
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/SampleData.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Cards/SampleData.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Cards
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Cards
 {
     public class SampleData
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Delete/DeleteDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Delete/DeleteDialog.cs
@@ -4,11 +4,10 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Delete
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Delete
 {
     public class DeleteDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/FileUpload/FileUploadDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/FileUpload/FileUploadDialog.cs
@@ -5,11 +5,10 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.FileUpload
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.FileUpload
 {
     public class FileUploadDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/MessageWithAttachment/MessageWithAttachmentDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/MessageWithAttachment/MessageWithAttachmentDialog.cs
@@ -6,12 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.MessageWithAttachment
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.MessageWithAttachment
 {
     public class MessageWithAttachmentDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Proactive/ContinuationParameters.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Proactive/ContinuationParameters.cs
@@ -4,7 +4,7 @@
 using System.Security.Principal;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proactive
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Proactive
 {
     /// <summary>
     /// Stores the information needed to resume a conversation when a proactive message arrives.

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
@@ -7,11 +7,10 @@ using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proactive
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Proactive
 {
     public class WaitForProactiveDialog : Dialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillDialog.cs
@@ -5,13 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Sso
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Sso
 {
     public class SsoSkillDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillSignInDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillSignInDialog.cs
@@ -5,9 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Sso
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Sso
 {
     public class SsoSkillSignInDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Update/UpdateDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Update/UpdateDialog.cs
@@ -4,11 +4,10 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Update
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Update
 {
     public class UpdateDialog : ComponentDialog
     {

--- a/Bots/DotNet/WaterfallSkillBot/Middleware/SsoSaveStateMiddleware.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Middleware/SsoSaveStateMiddleware.cs
@@ -6,10 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Middleware
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Middleware
 {
     /// <summary>
     /// A middleware that ensures conversation state is saved when an OAuthCard is returned by the skill.

--- a/Bots/DotNet/WaterfallSkillBot/Program.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Program.cs
@@ -4,7 +4,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot
 {
     public class Program
     {

--- a/Bots/DotNet/WaterfallSkillBot/SkillAdapterWithErrorHandler.cs
+++ b/Bots/DotNet/WaterfallSkillBot/SkillAdapterWithErrorHandler.cs
@@ -3,15 +3,14 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Middleware;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Middleware;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot
 {
     public class SkillAdapterWithErrorHandler : CloudAdapter
     {

--- a/Bots/DotNet/WaterfallSkillBot/Startup.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Startup.cs
@@ -5,20 +5,19 @@ using System;
 using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Bots;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs;
+using Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.Dialogs.Proactive;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Bots;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proactive;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot
+namespace Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot
 {
     public class Startup
     {


### PR DESCRIPTION
Fixes # 554

## Description
This PR updates the namespaces in the bots' classes to be aligned with the Bot Framework namespaces.

### Detailed description
- Updated namespaces in the classes of the following bots:
   - WaterfallHostBot
   - WaterfallSkillBot
- Reordered using statements and removed the unnecessary ones.

## Testing
These images show the pipelines running after the changes.
![image](https://user-images.githubusercontent.com/44245136/156376330-914bcb00-9718-4e28-b2c4-31589a601681.png)