### PR TITLE
[#548] Update bots to support SingleTenant & MSI authentications

### DIFF
--- a/Bots/JavaScript/EchoSkillBot/.env
+++ b/Bots/JavaScript/EchoSkillBot/.env
@@ -1,3 +1,5 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 AllowedCallers=*

--- a/Bots/JavaScript/EchoSkillBot/index.js
+++ b/Bots/JavaScript/EchoSkillBot/index.js
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 // Import required bot configuration.
-require('dotenv').config();
+require("dotenv").config();
 
-const http = require('http');
-const https = require('https');
-const restify = require('restify');
+const http = require("http");
+const https = require("https");
+const restify = require("restify");
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
@@ -15,19 +15,19 @@ const {
   CallerIdConstants,
   CloudAdapter,
   InputHints,
-  MessageFactory
-} = require('botbuilder');
+  MessageFactory,
+} = require("botbuilder");
 
 const {
   AuthenticationConfiguration,
   AuthenticationConstants,
   BotFrameworkAuthenticationFactory,
   PasswordServiceClientCredentialFactory,
-  allowedCallersClaimsValidator
-} = require('botframework-connector');
+  allowedCallersClaimsValidator,
+} = require("botframework-connector");
 
 // This bot's main dialog.
-const { EchoBot } = require('./bot.js');
+const { EchoBot } = require("./bot.js");
 
 // Create HTTP server
 const server = restify.createServer({ maxParamLength: 1000 });
@@ -38,17 +38,17 @@ server.use(restify.plugins.bodyParser());
 server.listen(process.env.port || process.env.PORT || 36400, () => {
   console.log(`\n${server.name} listening to ${server.url}`);
   console.log(
-    '\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator'
+    "\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator"
   );
   console.log('\nTo talk to your bot, open the emulator select "Open Bot"');
 });
 
 // Expose the manifest
 server.get(
-  '/manifests/*',
+  "/manifests/*",
   restify.plugins.serveStatic({
-    directory: './manifests',
-    appendRequestPath: false
+    directory: "./manifests",
+    appendRequestPath: false,
   })
 );
 
@@ -64,15 +64,34 @@ const maxTotalSockets = (
   );
 
 const allowedCallers =
-  (process.env.AllowedCallers || '').split(',').filter((val) => val) || [];
+  (process.env.AllowedCallers || "").split(",").filter((val) => val) || [];
 
+const claimsValidators = allowedCallersClaimsValidator(allowedCallers);
+
+// If the MicrosoftAppTenantId is specified in the environment config, add the tenant as a valid JWT token issuer for Bot to Skill conversation.
+// The token issuer for MSI and single tenant scenarios will be the tenant where the bot is registered.
+let validTokenIssuers = [];
+const { MicrosoftAppTenantId } = process.env;
+
+if (MicrosoftAppTenantId) {
+  // For SingleTenant/MSI auth, the JWT tokens will be issued from the bot's home tenant.
+  // Therefore, these issuers need to be added to the list of valid token issuers for authenticating activity requests.
+  validTokenIssuers = [
+    `${AuthenticationConstants.ValidTokenIssuerUrlTemplateV1}${MicrosoftAppTenantId}/`,
+    `${AuthenticationConstants.ValidTokenIssuerUrlTemplateV2}${MicrosoftAppTenantId}/v2.0/`,
+    `${AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1}${MicrosoftAppTenantId}/`,
+    `${AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2}${MicrosoftAppTenantId}/v2.0/`,
+  ];
+}
+
+// Define our authentication configuration.
 const authConfig = new AuthenticationConfiguration(
   [],
-  allowedCallersClaimsValidator(allowedCallers)
+  claimsValidators,
+  validTokenIssuers
 );
-
 const botFrameworkAuthentication = BotFrameworkAuthenticationFactory.create(
-  '',
+  "",
   true,
   AuthenticationConstants.ToChannelFromBotLoginUrl,
   AuthenticationConstants.ToChannelFromBotOAuthScope,
@@ -82,8 +101,10 @@ const botFrameworkAuthentication = BotFrameworkAuthenticationFactory.create(
   AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
   CallerIdConstants.PublicAzureChannel,
   new PasswordServiceClientCredentialFactory(
-    process.env.MicrosoftAppId || '',
-    process.env.MicrosoftAppPassword || ''
+    process.env.MicrosoftAppId || "",
+    process.env.MicrosoftAppPassword || "",
+    process.env.MicrosoftAppType || "",
+    process.env.MicrosoftAppTenantId || ""
   ),
   authConfig,
   undefined,
@@ -91,13 +112,13 @@ const botFrameworkAuthentication = BotFrameworkAuthenticationFactory.create(
     agentSettings: {
       http: new http.Agent({
         keepAlive: true,
-        maxTotalSockets: maxTotalSockets(1024, 4, 0.3)
+        maxTotalSockets: maxTotalSockets(1024, 4, 0.3),
       }),
       https: new https.Agent({
         keepAlive: true,
-        maxTotalSockets: maxTotalSockets(1024, 4, 0.7)
-      })
-    }
+        maxTotalSockets: maxTotalSockets(1024, 4, 0.7),
+      }),
+    },
   }
 );
 
@@ -116,7 +137,7 @@ adapter.onTurnError = async (context, error) => {
     const { message, stack } = error;
 
     // Send a message to the user.
-    let errorMessageText = 'The skill encountered an error or bug.';
+    let errorMessageText = "The skill encountered an error or bug.";
     let errorMessage = MessageFactory.text(
       `${errorMessageText}\r\n${message}\r\n${stack}`,
       errorMessageText,
@@ -126,7 +147,7 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity(errorMessage);
 
     errorMessageText =
-      'To continue to run this bot, please fix the bot source code.';
+      "To continue to run this bot, please fix the bot source code.";
     errorMessage = MessageFactory.text(
       errorMessageText,
       errorMessageText,
@@ -136,18 +157,18 @@ adapter.onTurnError = async (context, error) => {
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator
     await context.sendTraceActivity(
-      'OnTurnError Trace',
+      "OnTurnError Trace",
       `${error}`,
-      'https://www.botframework.com/schemas/error',
-      'TurnError'
+      "https://www.botframework.com/schemas/error",
+      "TurnError"
     );
 
     // Send and EndOfConversation activity to the skill caller with the error to end the conversation
     // and let the caller decide what to do.
     await context.sendActivity({
       type: ActivityTypes.EndOfConversation,
-      code: 'SkillError',
-      text: error.message
+      code: "SkillError",
+      text: error.message,
     });
   } catch (err) {
     console.error(`\n [onTurnError] Exception caught in onTurnError : ${err}`);
@@ -158,7 +179,7 @@ adapter.onTurnError = async (context, error) => {
 const myBot = new EchoBot();
 
 // Listen for incoming requests.
-server.post('/api/messages', async (req, res) => {
+server.post("/api/messages", async (req, res) => {
   await adapter.process(req, res, async (context) => {
     // Route to main dialog.
     await myBot.run(context);


### PR DESCRIPTION
Addresses #3526

### Proposed Changes
This PR adds support for MSI and SingleTenant functionalities to the Host and Skill under echo-bot by updating the .env file to include the MicrosoftAppType and MicrosoftAppTenantId fields and the registration of valid token issuers when the MicrosoftAppTenantId is provided.

### Detailed Changes

- Added the MicrosoftAppType and MicrosoftAppTenantId fields to the .env file and in the ConfigurationServiceClientCredentialFactory instance.
- Added valid token issuers to the AuthenticationConfiguration instance when the MicrosoftAppTenantId is provided.





