### PR TITLE
port: [#4044] Add obsolete attribute to BotFrameworkHttpAdapter and related classes. (#6096)

### DIFF
--- a/Bots/JavaScript/SimpleHostBot/.env
+++ b/Bots/JavaScript/SimpleHostBot/.env
@@ -1,5 +1,7 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 SkillHostEndpoint=http://localhost:36000/api/skills/
 
 skill_EchoSkillBotComposerDotNet_appId=


### PR DESCRIPTION
Addresses #123 

### Proposed Changes
This PR adds support for MSI and SingleTenant functionalities to the Host and Skill under simple-host bot by updating the .env file to include the MicrosoftAppType and MicrosoftAppTenantId fields and the registration of valid token issuers when the MicrosoftAppTenantId is provided.

### Detailed Changes
Added the MicrosoftAppType and MicrosoftAppTenantId fields to the .env file and in the ConfigurationServiceClientCredentialFactory instance.
Added valid token issuers to the AuthenticationConfiguration instance when the MicrosoftAppTenantId is provided.