### PR TITLE
[#503] Centralize BotBuilder version - Python

### DIFF
--- a/Bots/Python/EchoSkillBot/requirements.txt
+++ b/Bots/Python/EchoSkillBot/requirements.txt
@@ -1,1 +1,1 @@
-botbuilder-integration-aiohttp>=4.14.0
+-r ../requirements.txt

--- a/Bots/Python/SimpleHostBot/requirements.txt
+++ b/Bots/Python/SimpleHostBot/requirements.txt
@@ -1,3 +1,1 @@
-botbuilder-integration-aiohttp>=4.14.0
-botbuilder-dialogs>=4.14.0
-python-dotenv
+-r ../requirements.txt

--- a/Bots/Python/WaterfallHostBot/requirements.txt
+++ b/Bots/Python/WaterfallHostBot/requirements.txt
@@ -1,3 +1,1 @@
-botbuilder-integration-aiohttp>=4.14.0
-botbuilder-dialogs>=4.14.0
-python-dotenv~=0.15.0
+-r ../requirements.txt

--- a/Bots/Python/WaterfallSkillBot/requirements.txt
+++ b/Bots/Python/WaterfallSkillBot/requirements.txt
@@ -1,3 +1,1 @@
-botbuilder-integration-aiohttp>=4.14.0
-botbuilder-dialogs>=4.14.0
-python-dotenv
+-r ../requirements.txt

--- a/Bots/Python/requirements.txt
+++ b/Bots/Python/requirements.txt
@@ -1,0 +1,3 @@
+botbuilder-integration-aiohttp>=4.14.0
+botbuilder-dialogs>=4.14.0
+python-dotenv

--- a/build/yaml/deployBotResources/python/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/python/evaluateDependenciesVariables.yml
@@ -60,12 +60,12 @@ steps:
             }
           }
 
-          ## Update requirements.txt
+          # Update requirements.txt
           $file = "${{ parameters.source }}/requirements.txt"
           $content = @(Get-Content $file)
           $rootFile = "Bots/Python/requirements.txt"
 
-          # replace root requirements.txt reference with file content
+          # Replace root requirements.txt reference with file content
           $matchref = Select-String -Path $file -Pattern "-r ../requirements.txt"
           if($matchref.LineNumber -gt 0) {
               $content[$matchinfo.LineNumber - 1] = @(Get-Content $rootFile)

--- a/build/yaml/deployBotResources/python/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/python/evaluateDependenciesVariables.yml
@@ -60,10 +60,19 @@ steps:
             }
           }
 
-          # Add the $source source at the beginning of requirements
+          ## Update requirements.txt
           $file = "${{ parameters.source }}/requirements.txt"
           $content = @(Get-Content $file)
+          $rootFile = "Bots/Python/requirements.txt"
 
+          # replace root requirements.txt reference with file content
+          $matchref = Select-String -Path $file -Pattern "-r ../requirements.txt"
+          if($matchref.LineNumber -gt 0) {
+              $content[$matchinfo.LineNumber - 1] = @(Get-Content $rootFile)
+              Set-Content -Path $file -Value $content
+          }
+
+          # Add the $source source at the beginning of requirements
           if (-not ([string]::IsNullOrEmpty("$extraSource"))) {
             $extraSourceTag = "--extra-index-url $extraSource"
           }
@@ -99,7 +108,7 @@ steps:
           Write-Host "`nSource: $source"
           Write-Host "Extra Source: $extraSource"
           Write-Host "Version Number: $versionNumber"
-      
+
           $content = @(Get-Content $file)
           Write-Host "`nrequirements.txt file:"
           $content


### PR DESCRIPTION
Addresses # 503

## Description
This PR adds a `requirement.txt` file in `Bots/Python` folder to be referenced in each bot's _requirement.txt_ having the packages and their versions centralized in one place.

## Specific Changes
- Added a `requirement.txt` in `Bots/Python` with the packages and versions used by the bots.
- Updated each bot's `requirement.txt` to reference the one in the root folder.
- Updated the `evaluateDependenciesVariables` script to replace the reference in the bot's _requirement.txt_ with the content of the root file.

## Testing
The following images show the pipelines passing using different combinations of version and feed.
![image](https://user-images.githubusercontent.com/44245136/159031690-5a2a6dee-56f8-40f9-a4b0-a5b28aa09876.png)
![image](https://user-images.githubusercontent.com/44245136/159031713-bd629cd1-8236-4a5a-b62a-3decada53554.png)
![image](https://user-images.githubusercontent.com/44245136/159031732-f1f4b0d0-d2d7-4366-b9f3-0204a9a51aa3.png)