### PR TITLE
 [548] Update bots to support SingleTenant & MSI authentications

### DIFF
--- a/Bots/DotNet/EchoSkillBot/Startup.cs
+++ b/Bots/DotNet/EchoSkillBot/Startup.cs
@@ -51,9 +51,10 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
                 return new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(callers) };
             });
 
+               // Create the Bot Framework Authentication to be used with the Bot Adapter.
             services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Adapter with error handling enabled. 
             services.AddSingleton<IBotFrameworkHttpAdapter, SkillAdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/Bots/DotNet/EchoSkillBot/appsettings.json
+++ b/Bots/DotNet/EchoSkillBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "ChannelService": "",
   // This is a comma separate list with the App IDs that will have access to the skill.
   // This setting is used in AllowedCallersClaimsValidator.


### PR DESCRIPTION
#123
### 
Proposed Changes
This PR adds support for MSI and SingleTenant functionalities to the Host and Skill under waterfall bots by updating the .env file to include the MicrosoftAppType and MicrosoftAppTenantId fields and the registration of valid token issuers when the MicrosoftAppTenantId is provided.

### Detailed Changes
- Added the MicrosoftAppType and MicrosoftAppTenantId fields to the .env file and in the ConfigurationServiceClientCredentialFactory instance.
- Added valid token issuers to the AuthenticationConfiguration instance when the MicrosoftAppTenantId is provided.