### PR TITLE
[#548] Update WaterfallSkillBot to support SingleTenant & MSI authentications

### DIFF
--- a/Bots/DotNet/WaterfallSkillBot/WaterfallSkillBot.csproj
+++ b/Bots/DotNet/WaterfallSkillBot/WaterfallSkillBot.csproj
@@ -25,9 +25,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="$(BotBuilderVersion)" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="$(BotBuilderVersion)" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="$(BotBuilderVersion)" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 

--- a/Bots/DotNet/WaterfallSkillBot/appsettings.json
+++ b/Bots/DotNet/WaterfallSkillBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "ConnectionName": "TestOAuthProvider",
   "SsoConnectionName": "",
   "ChannelService": "",


### PR DESCRIPTION
Addresses #3526

### Proposed Changes
This PR adds support for MSI and SingleTenant functionalities to the Host and Skill under waterfall-bot by updating the appsettings.json file to include the MicrosoftAppType and MicrosoftAppTenantId fields and the registration of valid token issuers when the MicrosoftAppTenantId is provided.

### Detailed Changes
- Added the MicrosoftAppType and MicrosoftAppTenantId fields to the .env file and in the ConfigurationServiceClientCredentialFactory instance.
- Added valid token issuers to the AuthenticationConfiguration instance when the MicrosoftAppTenantId is provided.