### PR TITLE
[#503] Enable Cards tests for ComposerSkillBotDotNet

### DIFF
--- a/Bots/DotNet/ComposerSkillBotDotNet/dialogs/CardsDialog/language-generation/en-us/CardsDialog.en-us.lg
+++ b/Bots/DotNet/ComposerSkillBotDotNet/dialogs/CardsDialog/language-generation/en-us/CardsDialog.en-us.lg
@@ -16,6 +16,7 @@
 # ChoiceInput_Prompt_CQChcR()
 [Activity
     Text = ${ChoiceInput_Prompt_CQChcR_text()}
+    Speak = ${ChoiceInput_Prompt_CQChcR_text()}
 ]
 
 # ChoiceInput_Prompt_CQChcR_text()

--- a/Bots/DotNet/ComposerSkillBotDotNet/dialogs/FileUploadDialog/language-generation/en-us/FileUploadDialog.en-us.lg
+++ b/Bots/DotNet/ComposerSkillBotDotNet/dialogs/FileUploadDialog/language-generation/en-us/FileUploadDialog.en-us.lg
@@ -3,6 +3,7 @@
 # AttachmentInput_Prompt_JKtU0T()
 [Activity
     Text = ${AttachmentInput_Prompt_JKtU0T_text()}
+    InputHint = acceptingInput
 ]
 
 # AttachmentInput_Prompt_JKtU0T_text()
@@ -10,6 +11,7 @@
 # AttachmentInput_UnrecognizedPrompt_JKtU0T()
 [Activity
     Text = ${AttachmentInput_UnrecognizedPrompt_JKtU0T_text()}
+    InputHint = acceptingInput
 ]
 
 # AttachmentInput_UnrecognizedPrompt_JKtU0T_text()
@@ -17,11 +19,11 @@
 # SendActivity_ZBBqzI()
 [Activity
     Text = ${SendActivity_ZBBqzI_text()}
+    InputHint = acceptingInput
 ]
 
 # SendActivity_ZBBqzI_text()
-- ```Attachment "${dialog.file.Name}" has been received.
-File content: ${dialog.fileContent}```
+- ```Attachment "${dialog.file.Name}" has been received.\r\nFile content: ${dialog.fileContent}```
 # ConfirmInput_Prompt_9WovlS()
 [Activity
     Text = ${ConfirmInput_Prompt_9WovlS_text()}

--- a/Bots/DotNet/ComposerSkillBotDotNet/dialogs/MessageWithAttachmentDialog/language-generation/en-us/MessageWithAttachmentDialog.en-us.lg
+++ b/Bots/DotNet/ComposerSkillBotDotNet/dialogs/MessageWithAttachmentDialog/language-generation/en-us/MessageWithAttachmentDialog.en-us.lg
@@ -22,6 +22,7 @@
 # SendActivity_uWZAVE()
 [Activity
     Text = ${SendActivity_uWZAVE_text()}
+    InputHint = ignoringInput
     Attachments = ${AttachmentTemplate('Files/architecture-resize.png', 'image/png', `${conversation.HostUrl}/images/architecture-resize.png`)}
 ]
 # SendActivity_uWZAVE_text()
@@ -43,6 +44,7 @@
 # SendActivity_4HOnje()
 [Activity
     Text = ${SendActivity_4HOnje_text()}
+    InputHint = ignoringInput
     Attachments = ${AttachmentTemplate('Files/architecture-resize.png', 'image/png', `data:image/png;base64,${base64(GetFile())}`)}
 ]
 

--- a/Bots/DotNet/ComposerSkillBotDotNet/language-generation/en-us/common.en-us.lg
+++ b/Bots/DotNet/ComposerSkillBotDotNet/language-generation/en-us/common.en-us.lg
@@ -69,12 +69,14 @@
 [Activity
     Attachments = ${HeroCard()} | ${HeroCard()} | ${HeroCard()}
     AttachmentLayout = carousel
+    InputHint = acceptingInput
 ]
 
 # ListTemplate
 [Activity
     Attachments = ${HeroCard()} | ${HeroCard()} | ${HeroCard()}
     AttachmentLayout = list
+    InputHint = acceptingInput
 ]
 
 # AnimationCard
@@ -122,16 +124,22 @@
 # AdaptiveCardBotAction
 [Activity
     Attachments = ${json(adaptivecardbotactionjson())}
+    AttachmentLayout = list
+    InputHint = acceptingInput
 ]
 
 # AdaptiveCardSubmitAction
 [Activity
     Attachments = ${json(adaptivecardsubmitactionjson())}
+    AttachmentLayout = list
+    InputHint = acceptingInput
 ]
 
 # AdaptiveCardTaskModule
 [Activity
     Attachments = ${json(adaptivecardtaskmodulejson())}
+    AttachmentLayout = list
+    InputHint = acceptingInput
 ]
 
 # TeamsFileConsent
@@ -142,6 +150,8 @@
 # O365Card
 [Activity
     Attachments = ${json(o365cardjson())}
+    AttachmentLayout = list
+    InputHint = acceptingInput
 ]
 
 # adaptivecardbotactionjson()
@@ -282,11 +292,242 @@
 # o365cardjson()
 - ```
 {
-  "type": "MessageCard",
+  "type": "application/vnd.microsoft.teams.card.o365connector",
   "context": "http://schema.org/extensions",
-  "summary": "John Doe commented on Trello",
-  "title": "Project Tango",
-  "sections": [],
-  "potentialAction": []
+  "summary": "O365 card summary",
+  "title": "card title",
+  "text": "card text",
+  "themeColor": "#E67A9E",
+  "sections": [
+    {
+      "title": "**section title**",
+      "text": "section text",
+      "activityTitle": "activity title",
+      "activitySubtitle": "activity subtitle",
+      "activityText": "activity text",
+      "activityImage": "http://connectorsdemo.azurewebsites.net/images/MSC12_Oscar_002.jpg",
+      "activityImageType": "avatar",
+      "markdown": true,
+      "facts": [
+        {
+          "name": "Fact name 1",
+          "value": "Fact value 1"
+        },
+        {
+          "name": "Fact name 2",
+          "value": "Fact value 2"
+        }
+      ],
+      "images": [
+        {
+          "image": "http://connectorsdemo.azurewebsites.net/images/MicrosoftSurface_024_Cafe_OH-06315_VS_R1c.jpg",
+          "title": "image 1"
+        },
+        {
+          "image": "http://connectorsdemo.azurewebsites.net/images/WIN12_Scene_01.jpg",
+          "title": "image 2"
+        },
+        {
+          "image": "http://connectorsdemo.azurewebsites.net/images/WIN12_Anthony_02.jpg",
+          "title": "image 3"
+        }
+      ]
+    }
+  ],
+  "potentialAction": [
+    {
+      "@type": "ActionCard",
+      "inputs": [
+        {
+          "@type": "MultichoiceInput",
+          "choices": [
+            {
+              "display": "Choice 1"
+            },
+            {
+              "display": "Choice 2"
+            },
+            {
+              "display": "Choice 3"
+            }
+          ],
+          "style": "expanded",
+          "isMultiSelect": true,
+          "id": "list-1",
+          "isRequired": true,
+          "title": "Pick multiple options"
+        },
+        {
+          "@type": "MultichoiceInput",
+          "choices": [
+            {
+              "display": "Choice 4"
+            },
+            {
+              "display": "Choice 5"
+            },
+            {
+              "display": "Choice 6"
+            }
+          ],
+          "style": "compact",
+          "isMultiSelect": true,
+          "id": "list-2",
+          "isRequired": true,
+          "title": "Pick multiple options"
+        },
+        {
+          "@type": "MultichoiceInput",
+          "choices": [
+            {
+              "display": "Choice a",
+              "value": "a"
+            },
+            {
+              "display": "Choice b",
+              "value": "b"
+            },
+            {
+              "display": "Choice c",
+              "value": "c"
+            }
+          ],
+          "style": "expanded",
+          "isMultiSelect": false,
+          "id": "list-3",
+          "isRequired": false,
+          "title": "Pick an option"
+        },
+        {
+          "@type": "MultichoiceInput",
+          "choices": [
+            {
+              "display": "Choice x",
+              "value": "x"
+            },
+            {
+              "display": "Choice y",
+              "value": "y"
+            },
+            {
+              "display": "Choice z",
+              "value": "z"
+            }
+          ],
+          "style": "compact",
+          "isMultiSelect": false,
+          "id": "list-4",
+          "isRequired": false,
+          "title": "Pick an option"
+        }
+      ],
+      "actions": [
+        {
+          "@type": "HttpPOST",
+          "name": "Send",
+          "@id": "card-1-btn-1"
+        }
+      ],
+      "name": "Multiple Choice",
+      "@id": "card-1"
+    },
+    {
+      "@type": "ActionCard",
+      "inputs": [
+        {
+          "@type": "TextInput",
+          "isMultiline": true,
+          "id": "text-1",
+          "isRequired": false,
+          "title": "multiline, no maxLength"
+        },
+        {
+          "@type": "TextInput",
+          "isMultiline": false,
+          "id": "text-2",
+          "isRequired": false,
+          "title": "single line, no maxLength"
+        },
+        {
+          "@type": "TextInput",
+          "isMultiline": true,
+          "id": "text-3",
+          "isRequired": true,
+          "title": "multiline, max len = 10, isRequired"
+        },
+        {
+          "@type": "TextInput",
+          "isMultiline": false,
+          "id": "text-4",
+          "isRequired": true,
+          "title": "single line, max len = 10, isRequired"
+        }
+      ],
+      "actions": [
+        {
+          "@type": "HttpPOST",
+          "name": "Send",
+          "@id": "card-2-btn-1"
+        }
+      ],
+      "name": "Text Input",
+      "@id": "card-2"
+    },
+    {
+      "@type": "ActionCard",
+      "inputs": [
+        {
+          "@type": "DateInput",
+          "includeTime": true,
+          "id": "date-1",
+          "isRequired": true,
+          "title": "date with time"
+        },
+        {
+          "@type": "DateInput",
+          "includeTime": false,
+          "id": "date-2",
+          "isRequired": false,
+          "title": "date only"
+        }
+      ],
+      "actions": [
+        {
+          "@type": "HttpPOST",
+          "name": "Send",
+          "@id": "card-3-btn-1"
+        }
+      ],
+      "name": "Date Input",
+      "@id": "card-3"
+    },
+    {
+      "@type": "ViewAction",
+      "name": "View Action"
+    },
+    {
+      "@type": "OpenUri",
+      "targets": [
+        {
+          "os": "default",
+          "uri": "http://microsoft.com"
+        },
+        {
+          "os": "iOS",
+          "uri": "http://microsoft.com"
+        },
+        {
+          "os": "android",
+          "uri": "http://microsoft.com"
+        },
+        {
+          "os": "windows",
+          "uri": "http://microsoft.com"
+        }
+      ],
+      "name": "Open Uri",
+      "@id": "open-uri"
+    }
+  ]
 }
 ```

--- a/Tests/Functional/Skills/CardActions/AnimationCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/AnimationCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class AnimationCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public AnimationCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "Animation.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/AudioCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/AudioCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class AudioCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public AudioCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "Audio.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/BotActionCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/BotActionCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class BotActionCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public BotActionCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "BotAction.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/CardActionsTests.cs
+++ b/Tests/Functional/Skills/CardActions/CardActionsTests.cs
@@ -49,9 +49,7 @@ namespace SkillFunctionalTests.Skills.CardActions
                 SkillBotNames.WaterfallSkillBotDotNet,
                 SkillBotNames.WaterfallSkillBotJS,
                 SkillBotNames.WaterfallSkillBotPython,
-
-                // TODO: Enable this when the port to composer is ready
-                //SkillBotNames.ComposerSkillBotDotNet
+                SkillBotNames.ComposerSkillBotDotNet
             };
 
             var scripts = new List<string>

--- a/Tests/Functional/Skills/CardActions/CarouselCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/CarouselCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class CarouselCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public CarouselCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "Carousel.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/HeroCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/HeroCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class HeroCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public HeroCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "Hero.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/ListCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/ListCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class ListCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public ListCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "List.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/O365CardTests.cs
+++ b/Tests/Functional/Skills/CardActions/O365CardTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class O365CardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public O365CardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "O365.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+
+            // This local function is used to exclude ExpectReplies, O365 and WaterfallSkillBotPython test cases
+            static bool ShouldExclude(TestCase testCase)
+            {
+                if (testCase.Script == "O365.json")
+                {
+                    // BUG: O365 fails with ExpectReplies for WaterfallSkillBotPython (remove when https://github.com/microsoft/BotFramework-FunctionalTests/issues/328 is fixed).
+                    if (testCase.TargetSkill == SkillBotNames.WaterfallSkillBotPython && testCase.DeliveryMode == DeliveryModes.ExpectReplies)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/ReceiptCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/ReceiptCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class ReceiptCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public ReceiptCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "Receipt.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/SignInCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/SignInCardTests.cs
@@ -17,11 +17,11 @@ using Xunit.Abstractions;
 namespace SkillFunctionalTests.Skills.CardActions
 {
     [Trait("TestCategory", "CardActions")]
-    public class CardActionsTests : ScriptTestBase
+    public class SignInCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
 
-        public CardActionsTests(ITestOutputHelper output)
+        public SignInCardTests(ITestOutputHelper output)
             : base(output)
         {
         }
@@ -54,39 +54,12 @@ namespace SkillFunctionalTests.Skills.CardActions
 
             var scripts = new List<string>
             {
-                "BotAction.json",
-                "TaskModule.json",
-                "SubmitAction.json",
-                "Hero.json",
-                "Thumbnail.json",
-                "Receipt.json",
-                "SignIn.json",
-                "Carousel.json",
-                "List.json",
-                "O365.json",
-                "Animation.json",
-                "Audio.json",
-                "Video.json"
+                "SignIn.json"
             };
 
             var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
 
-            // This local function is used to exclude ExpectReplies, O365 and WaterfallSkillBotPython test cases
-            static bool ShouldExclude(TestCase testCase)
-            {
-                if (testCase.Script == "O365.json")
-                {
-                    // BUG: O365 fails with ExpectReplies for WaterfallSkillBotPython (remove when https://github.com/microsoft/BotFramework-FunctionalTests/issues/328 is fixed).
-                    if (testCase.TargetSkill == SkillBotNames.WaterfallSkillBotPython && testCase.DeliveryMode == DeliveryModes.ExpectReplies)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Skills/CardActions/SubmitActionCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/SubmitActionCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class SubmitActionCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public SubmitActionCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "SubmitAction.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/TaskModuleCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/TaskModuleCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class TaskModuleCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public TaskModuleCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "TaskModule.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/ThumbnailCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/ThumbnailCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class ThumbnailCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public ThumbnailCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "Thumbnail.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/CardActions/VideoCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/VideoCardTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Skills.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Skills.CardActions
+{
+    [Trait("TestCategory", "CardActions")]
+    public class VideoCardTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";
+
+        public VideoCardTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var channelIds = new List<string> { Channels.Directline };
+            
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
+            };
+
+            var hostBots = new List<HostBot>
+            {
+                HostBot.ComposerHostBotDotNet,
+                HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotJS,
+                HostBot.WaterfallHostBotPython,
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotJS,
+                SkillBotNames.WaterfallSkillBotPython,
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "Video.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
+        }
+    }
+}

--- a/Tests/Functional/Skills/FileUpload/TestScripts/FileUpload1.json
+++ b/Tests/Functional/Skills/FileUpload/TestScripts/FileUpload1.json
@@ -189,7 +189,8 @@
         "type == 'message'",
         "from.role == 'bot'",
         "recipient.role == 'user'",
-        "text == 'Please upload a file to continue.'"
+        "text == 'Please upload a file to continue.'",
+        "inputHint == 'acceptingInput'"
       ]
     },
     {

--- a/Tests/Functional/Skills/FileUpload/TestScripts/FileUpload2.json
+++ b/Tests/Functional/Skills/FileUpload/TestScripts/FileUpload2.json
@@ -8,7 +8,8 @@
         "type == 'message'",
         "from.role == 'bot'",
         "recipient.role == 'user'",
-        "startsWith(text, 'Attachment \"${FileName}\" has been received.\r\nFile content: GUID:${TestGuid}')"
+        "startsWith(text, 'Attachment \"${FileName}\" has been received.\r\nFile content: GUID:${TestGuid}')",
+        "inputHint == 'acceptingInput'"
       ]
     },
     {

--- a/Tests/Functional/Skills/MessageWithAttachment/TestScripts/MessageWithAttachment.json
+++ b/Tests/Functional/Skills/MessageWithAttachment/TestScripts/MessageWithAttachment.json
@@ -236,6 +236,7 @@
         "from.role == 'bot'",
         "recipient.role == 'user'",
         "text == 'This is an inline attachment.'",
+        "inputHint == 'ignoringInput'",
         "attachments[0].contentType == 'image/png'",
         "attachments[0].name == 'Files/architecture-resize.png'"
       ]
@@ -341,6 +342,7 @@
         "from.role == 'bot'",
         "recipient.role == 'user'",
         "text == 'This is an attachment from a HTTP URL.'",
+        "inputHint == 'ignoringInput'",
         "attachments[0].contentType == 'image/png'",
         "endsWith(attachments[0].contentUrl, 'images/architecture-resize.png')",
         "attachments[0].name == 'Files/architecture-resize.png'"


### PR DESCRIPTION
Addresses # 503

## Description
This PR updates the **_ComposerSkillBotDotNet_** adding the missing properties in _CardsDialog_ in order to enable the Cards scenario for this bot.
Also, it splits the **_CardActionTests_** class into different classes, one for each card type, to be able to run the tests in parallel reducing the execution time from over 50' to 7' approx.

### Detailed Changes
- Added **_missing properties_** in the following files:
   - CardsDialog.en-us.lg
   - FileUploadDialog.en-us.lg
   - MessageWithAttachmentDialog.en-us.lg
   - common.en-us.lg
- Updated **_O365Card_** template to match the one used in the tests.
- Re-added removed properties from _FileUpload1_, _FileUpload2_, and _MessageWithAttachments_ test scripts.
- Split the **_CardActionTests_** class into separate classes for each card type:
   - AnimationCardTests
   - AudioCardTests
   - BotActionCardTests
   - CarouselCardTests
   - HeroCardTests
   - ListCardTests
   - O365CardTests
   - ReceiptCardTests
   - SignInCardTests
   - SubmitActionCardTests
   - TaskModuleCardTests
   - ThumbnailCardTests
   - VideoCardTests
- Added **_ComposerSkillBotDotNet_** in the list of `targetSkills` in the card tests classes.

## Testing
These images show the Cards tests executing in parallel and the pipeline passing in less than 10 minutes.
![image](https://user-images.githubusercontent.com/44245136/159727219-86764353-9fc3-4642-ab10-03eb67b9ed8f.png)