### PR TITLE
[#548] Create Fn tests for supported authentication types - Update .NET bots

### DIFF
--- a/Bots/DotNet/EchoSkillBot/Startup.cs
+++ b/Bots/DotNet/EchoSkillBot/Startup.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
 using Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/Bots/DotNet/EchoSkillBot/Startup.cs
+++ b/Bots/DotNet/EchoSkillBot/Startup.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
@@ -33,19 +35,33 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
         {
             services.AddControllers().AddNewtonsoftJson();
 
+            // Register AuthConfiguration to enable custom claim validation.
             services.AddSingleton(sp =>
             {
-                // AllowedCallers is the setting in the appsettings.json file that consists of the list of parent bot IDs that are allowed to access the skill.
-                // To add a new parent bot, simply edit the AllowedCallers and add the parent bot's Microsoft app ID to the list.
-                // In this sample, we allow all callers if AllowedCallers contains an "*".
-                var callersSection = Configuration.GetSection(CallersConfigKey);
-                var callers = callersSection.Get<string[]>();
-                if (callers == null)
+                var allowedCallers = new List<string>(sp.GetService<IConfiguration>().GetSection(CallersConfigKey).Get<string[]>());
+
+                var claimsValidator = new AllowedCallersClaimsValidator(allowedCallers);
+
+                // If TenantId is specified in config, add the tenant as a valid JWT token issuer for Bot to Skill conversation.
+                // The token issuer for MSI and single tenant scenarios will be the tenant where the bot is registered.
+                var validTokenIssuers = new List<string>();
+                var tenantId = sp.GetService<IConfiguration>().GetSection(MicrosoftAppCredentials.MicrosoftAppTenantIdKey)?.Value;
+
+                if (!string.IsNullOrWhiteSpace(tenantId))
                 {
-                    throw new ArgumentNullException($"\"{CallersConfigKey}\" not found in configuration.");
+                    // For SingleTenant/MSI auth, the JWT tokens will be issued from the bot's home tenant.
+                    // Therefore, these issuers need to be added to the list of valid token issuers for authenticating activity requests.
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV1, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV2, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2, tenantId));
                 }
 
-                return new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(callers) };
+                return new AuthenticationConfiguration
+                {
+                    ClaimsValidator = claimsValidator,
+                    ValidTokenIssuers = validTokenIssuers
+                };
             });
 
             services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();

--- a/Bots/DotNet/EchoSkillBot/appsettings.json
+++ b/Bots/DotNet/EchoSkillBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "ChannelService": "",
   // This is a comma separate list with the App IDs that will have access to the skill.
   // This setting is used in AllowedCallersClaimsValidator.

--- a/Bots/DotNet/SimpleHostBot/AdapterWithErrorHandler.cs
+++ b/Bots/DotNet/SimpleHostBot/AdapterWithErrorHandler.cs
@@ -5,9 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
@@ -20,28 +18,27 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
+        private readonly BotFrameworkAuthentication _auth;
         private readonly ConversationState _conversationState;
         private readonly IConfiguration _configuration;
         private readonly ILogger _logger;
-        private readonly SkillHttpClient _skillClient;
         private readonly SkillsConfiguration _skillsConfig;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AdapterWithErrorHandler"/> class to handle errors.
         /// </summary>
-        /// <param name="botFrameworkAuthentication">The cloud environment for the bot.</param>
+        /// <param name="auth">The cloud environment for the bot.</param>
         /// <param name="configuration">The configuration properties.</param>
         /// <param name="logger">An instance of a logger.</param>
         /// <param name="conversationState">A state management object for the conversation.</param>
-        /// <param name="skillClient">The HTTP client for the skills.</param>
         /// <param name="skillsConfig">The skills configuration.</param>
-        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState = null, SkillHttpClient skillClient = null, SkillsConfiguration skillsConfig = null)
-            : base(botFrameworkAuthentication, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState = null, SkillsConfiguration skillsConfig = null)
+            : base(auth, logger)
         {
+            _auth = auth ?? throw new ArgumentNullException(nameof(auth));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _conversationState = conversationState;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _skillClient = skillClient;
             _skillsConfig = skillsConfig;
 
             OnTurnError = HandleTurnErrorAsync;
@@ -104,7 +101,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         private async Task EndSkillConversationAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
-            if (_conversationState == null || _skillClient == null || _skillsConfig == null)
+            if (_conversationState == null || _skillsConfig == null)
             {
                 return;
             }
@@ -123,7 +120,9 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
                     endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
 
                     await _conversationState.SaveChangesAsync(turnContext, true, cancellationToken);
-                    await _skillClient.PostActivityAsync(botId, activeSkill, _skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, cancellationToken);
+
+                    using var client = _auth.CreateBotFrameworkClient();
+                    await client.PostActivityAsync(botId, activeSkill.AppId, activeSkill.SkillEndpoint, _skillsConfig.SkillHostEndpoint, endOfConversation.Conversation.Id, (Activity)endOfConversation, cancellationToken);
                 }
             }
             catch (Exception ex)

--- a/Bots/DotNet/SimpleHostBot/Bots/HostBot.cs
+++ b/Bots/DotNet/SimpleHostBot/Bots/HostBot.cs
@@ -3,19 +3,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Dialogs;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots
 {
@@ -28,24 +27,27 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots
         private readonly IStatePropertyAccessor<BotFrameworkSkill> _activeSkillProperty;
         private readonly IStatePropertyAccessor<DialogState> _dialogStateProperty;
         private readonly string _botId;
+        private readonly BotFrameworkAuthentication _auth;
         private readonly ConversationState _conversationState;
-        private readonly SkillHttpClient _skillClient;
         private readonly SkillsConfiguration _skillsConfig;
+        private readonly SkillConversationIdFactoryBase _conversationIdFactory;
         private readonly Dialog _dialog;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HostBot"/> class.
         /// </summary>
+        /// <param name="auth">The cloud environment for the bot.</param>
         /// <param name="conversationState">A state management object for the conversation.</param>
         /// <param name="skillsConfig">The skills configuration.</param>
-        /// <param name="skillClient">The HTTP client for the skills.</param>
         /// <param name="configuration">The configuration properties.</param>
+        /// <param name="conversationIdFactory">The conversation id factory.</param>
         /// <param name="dialog">The dialog to use.</param>
-        public HostBot(ConversationState conversationState, SkillsConfiguration skillsConfig, SkillHttpClient skillClient, IConfiguration configuration, SetupDialog dialog)
+        public HostBot(BotFrameworkAuthentication auth, ConversationState conversationState, SkillsConfiguration skillsConfig, SkillConversationIdFactoryBase conversationIdFactory, IConfiguration configuration, SetupDialog dialog)
         {
+            _auth = auth ?? throw new ArgumentNullException(nameof(auth));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
-            _skillClient = skillClient ?? throw new ArgumentNullException(nameof(skillClient));
+            _conversationIdFactory = conversationIdFactory ?? throw new ArgumentNullException(nameof(conversationIdFactory));
             _dialog = dialog ?? throw new ArgumentNullException(nameof(dialog));
             _dialogStateProperty = _conversationState.CreateProperty<DialogState>("DialogState");
             if (configuration == null)
@@ -196,14 +198,28 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots
             // will have access to current accurate state.
             await _conversationState.SaveChangesAsync(turnContext, force: true, cancellationToken: cancellationToken);
 
+            // Route the activity to the skill.
+            using var client = _auth.CreateBotFrameworkClient();
+
+            // Create a conversationId to interact with the skill and send the activity
+            var options = new SkillConversationIdFactoryOptions
+            {
+                FromBotOAuthScope = turnContext.TurnState.Get<string>(BotAdapter.OAuthScopeKey),
+                FromBotId = _botId,
+                Activity = turnContext.Activity,
+                BotFrameworkSkill = targetSkill
+            };
+
+            var skillConversationId = await _conversationIdFactory.CreateSkillConversationIdAsync(options, cancellationToken);
+
             if (deliveryMode == DeliveryModes.ExpectReplies)
             {
                 // Clone activity and update its delivery mode.
                 var activity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(turnContext.Activity));
                 activity.DeliveryMode = deliveryMode;
 
-                // Route the activity to the skill.
-                var expectRepliesResponse = await _skillClient.PostActivityAsync<ExpectedReplies>(_botId, targetSkill, _skillsConfig.SkillHostEndpoint, activity, cancellationToken);
+                // route the activity to the skill
+                var expectRepliesResponse = await client.PostActivityAsync(_botId, targetSkill.AppId, targetSkill.SkillEndpoint, _skillsConfig.SkillHostEndpoint, skillConversationId, activity, cancellationToken);
 
                 // Check response status.
                 if (!expectRepliesResponse.IsSuccessStatusCode())
@@ -212,7 +228,9 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots
                 }
 
                 // Route response activities back to the channel.
-                var responseActivities = expectRepliesResponse.Body?.Activities;
+                var response = expectRepliesResponse.Body as JObject;
+                var activities = response["activities"];
+                var responseActivities = activities.ToObject<IList<Activity>>();
 
                 foreach (var responseActivity in responseActivities)
                 {
@@ -229,7 +247,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots
             else
             {
                 // Route the activity to the skill.
-                var response = await _skillClient.PostActivityAsync(_botId, targetSkill, _skillsConfig.SkillHostEndpoint, (Activity)turnContext.Activity, cancellationToken);
+                var response = await client.PostActivityAsync(_botId, targetSkill.AppId, targetSkill.SkillEndpoint, _skillsConfig.SkillHostEndpoint, skillConversationId, turnContext.Activity, cancellationToken);
 
                 // Check response status
                 if (!response.IsSuccessStatusCode())

--- a/Bots/DotNet/SimpleHostBot/Controllers/SkillController.cs
+++ b/Bots/DotNet/SimpleHostBot/Controllers/SkillController.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.
-    /// This example uses the <see cref="SkillHandler"/> that is registered as a <see cref="ChannelServiceHandler"/> in startup.cs.
+    /// This example uses the <see cref="CloudSkillHandler"/> that is registered as a <see cref="ChannelServiceHandlerBase"/> in startup.cs.
     /// </summary>
     [ApiController]
     [Route("api/skills")]
@@ -19,8 +19,8 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Controllers
         /// <summary>
         /// Initializes a new instance of the <see cref="SkillController"/> class.
         /// </summary>
-        /// <param name="handler">The skill handler registered as ChannelServiceHandler.</param>
-        public SkillController(ChannelServiceHandler handler)
+        /// <param name="handler">The skill handler registered as ChannelServiceHandlerBase.</param>
+        public SkillController(ChannelServiceHandlerBase handler)
             : base(handler)
         {
         }

--- a/Bots/DotNet/SimpleHostBot/Startup.cs
+++ b/Bots/DotNet/SimpleHostBot/Startup.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Dialogs;
 using Microsoft.Extensions.Configuration;
@@ -39,12 +39,33 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
             // Register the skills configuration class
             services.AddSingleton<SkillsConfiguration>();
 
-            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
-
-            services.AddSingleton(sp => new AuthenticationConfiguration
+            // Register AuthConfiguration to enable custom claim validation.
+            services.AddSingleton(sp =>
             {
-                ClaimsValidator = new AllowedSkillsClaimsValidator(
-                (from skill in sp.GetService<SkillsConfiguration>().Skills.Values select skill.AppId).ToList())
+                var allowedSkills = sp.GetService<SkillsConfiguration>().Skills.Values.Select(s => s.AppId).ToList();
+
+                var claimsValidator = new AllowedSkillsClaimsValidator(allowedSkills);
+
+                // If TenantId is specified in config, add the tenant as a valid JWT token issuer for Bot to Skill conversation.
+                // The token issuer for MSI and single tenant scenarios will be the tenant where the bot is registered.
+                var validTokenIssuers = new List<string>();
+                var tenantId = sp.GetService<IConfiguration>().GetSection(MicrosoftAppCredentials.MicrosoftAppTenantIdKey)?.Value;
+
+                if (!string.IsNullOrWhiteSpace(tenantId))
+                {
+                    // For SingleTenant/MSI auth, the JWT tokens will be issued from the bot's home tenant.
+                    // Therefore, these issuers need to be added to the list of valid token issuers for authenticating activity requests.
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV1, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV2, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2, tenantId));
+                }
+
+                return new AuthenticationConfiguration
+                {
+                    ClaimsValidator = claimsValidator,
+                    ValidTokenIssuers = validTokenIssuers
+                };
             });
 
             services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
@@ -55,10 +76,9 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
             services.AddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetService<CloudAdapter>());
             services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>());
 
-            // Register the skills client and skills request handler.
+            // Register the skills conversation ID factory, the client and the request handler.
             services.AddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();
-            services.AddHttpClient<SkillHttpClient>();
-            services.AddSingleton<ChannelServiceHandler, SkillHandler>();
+            services.AddSingleton<ChannelServiceHandlerBase, CloudSkillHandler>();
             
             // Register the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
             services.AddSingleton<IStorage, MemoryStorage>();

--- a/Bots/DotNet/SimpleHostBot/appsettings.json
+++ b/Bots/DotNet/SimpleHostBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "ChannelService": "",
   "SkillHostEndpoint": "http://localhost:35000/api/skills/",
   "BotFrameworkSkills": [

--- a/Bots/DotNet/WaterfallHostBot/Controllers/SkillController.cs
+++ b/Bots/DotNet/WaterfallHostBot/Controllers/SkillController.cs
@@ -14,7 +14,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.
-    /// This example uses the <see cref="SkillHandler"/> that is registered as a <see cref="ChannelServiceHandler"/> in startup.cs.
+    /// This example uses the <see cref="CloudSkillHandler"/> that is registered as a <see cref="ChannelServiceHandlerBase"/> in startup.cs.
     /// </summary>
     [ApiController]
     [Route("api/skills")]
@@ -22,7 +22,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Controllers
     {
         private readonly ILogger _logger;
 
-        public SkillController(ChannelServiceHandler handler, ILogger<SkillController> logger)
+        public SkillController(ChannelServiceHandlerBase handler, ILogger<SkillController> logger)
             : base(handler)
         {
             _logger = logger;

--- a/Bots/DotNet/WaterfallHostBot/Dialogs/MainDialog.cs
+++ b/Bots/DotNet/WaterfallHostBot/Dialogs/MainDialog.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -32,23 +31,20 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
         private readonly IStatePropertyAccessor<BotFrameworkSkill> _activeSkillProperty;
         private readonly string _deliveryMode = $"{typeof(MainDialog).FullName}.DeliveryMode";
         private readonly string _selectedSkillKey = $"{typeof(MainDialog).FullName}.SelectedSkillKey";
+        private readonly BotFrameworkAuthentication _auth;
         private readonly SkillsConfiguration _skillsConfig;
         private readonly IConfiguration _configuration;
 
         // Dependency injection uses this constructor to instantiate MainDialog.
-        public MainDialog(ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient, SkillsConfiguration skillsConfig, IConfiguration configuration)
+        public MainDialog(BotFrameworkAuthentication auth, ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillsConfiguration skillsConfig, IConfiguration configuration)
             : base(nameof(MainDialog))
         {
+            _auth = auth ?? throw new ArgumentNullException(nameof(auth));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
             var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
 
             _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
-
-            if (skillClient == null)
-            {
-                throw new ArgumentNullException(nameof(skillClient));
-            }
 
             if (conversationState == null)
             {
@@ -62,7 +58,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             AddDialog(new TangentDialog());
 
             // Create and add SkillDialog instances for the configured skills.
-            AddSkillDialogs(conversationState, conversationIdFactory, skillClient, skillsConfig, botId);
+            AddSkillDialogs(conversationState, conversationIdFactory, skillsConfig, botId);
 
             // Add ChoicePrompt to render available delivery modes.
             AddDialog(new ChoicePrompt("DeliveryModePrompt"));
@@ -304,7 +300,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
         }
 
         // Helper method that creates and adds SkillDialog instances for the configured skills.
-        private void AddSkillDialogs(ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient, SkillsConfiguration skillsConfig, string botId)
+        private void AddSkillDialogs(ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillsConfiguration skillsConfig, string botId)
         {
             foreach (var skillInfo in _skillsConfig.Skills.Values)
             {
@@ -313,7 +309,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
                 {
                     BotId = botId,
                     ConversationIdFactory = conversationIdFactory,
-                    SkillClient = skillClient,
+                    SkillClient = _auth.CreateBotFrameworkClient(),
                     SkillHostEndpoint = skillsConfig.SkillHostEndpoint,
                     ConversationState = conversationState,
                     Skill = skillInfo

--- a/Bots/DotNet/WaterfallHostBot/Startup.cs
+++ b/Bots/DotNet/WaterfallHostBot/Startup.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
 using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Bots;
 using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs;
 using Microsoft.Extensions.Configuration;
@@ -37,14 +37,35 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
             // Register the skills configuration class.
             services.AddSingleton<SkillsConfiguration>();
 
-            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
-
-            services.AddSingleton(sp => new AuthenticationConfiguration
+            // Register AuthConfiguration to enable custom claim validation.
+            services.AddSingleton(sp =>
             {
-                ClaimsValidator = new AllowedSkillsClaimsValidator(
-                (from skill in sp.GetService<SkillsConfiguration>().Skills.Values select skill.AppId).ToList())
+                var allowedSkills = sp.GetService<SkillsConfiguration>().Skills.Values.Select(skill => skill.AppId).ToList();
+                var claimsValidator = new AllowedSkillsClaimsValidator(allowedSkills);
+
+                // If TenantId is specified in config, add the tenant as a valid JWT token issuer for Bot to Skill conversation.
+                // The token issuer for MSI and single tenant scenarios will be the tenant where the bot is registered.
+                var validTokenIssuers = new List<string>();
+                var tenantId = sp.GetService<IConfiguration>().GetSection(MicrosoftAppCredentials.MicrosoftAppTenantIdKey)?.Value;
+
+                if (!string.IsNullOrWhiteSpace(tenantId))
+                {
+                    // For SingleTenant/MSI auth, the JWT tokens will be issued from the bot's home tenant.
+                    // Therefore, these issuers need to be added to the list of valid token issuers for authenticating activity requests.
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV1, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV2, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1, tenantId));
+                    validTokenIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2, tenantId));
+                }
+
+                return new AuthenticationConfiguration
+                {
+                    ClaimsValidator = claimsValidator,
+                    ValidTokenIssuers = validTokenIssuers
+                };
             });
 
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
             services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
             // Register the Bot Framework Adapter with error handling enabled.
@@ -56,9 +77,9 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
 
             // Register the skills conversation ID factory, the client and the request handler.
             services.AddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();
-            services.AddHttpClient<SkillHttpClient>();
+            services.AddSingleton<ChannelServiceHandlerBase, CloudSkillHandler>();
 
-            services.AddSingleton<ChannelServiceHandler, TokenExchangeSkillHandler>();
+            services.AddSingleton<ChannelServiceHandlerBase, TokenExchangeSkillHandler>();
 
             // Register the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
             services.AddSingleton<IStorage, MemoryStorage>();

--- a/Bots/DotNet/WaterfallHostBot/TokenExchangeSkillHandler.cs
+++ b/Bots/DotNet/WaterfallHostBot/TokenExchangeSkillHandler.cs
@@ -14,14 +14,15 @@ using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
 {
     /// <summary>
-    /// A <see cref="SkillHandler"/> specialized to support SSO Token exchanges.
+    /// A <see cref="CloudSkillHandler"/> specialized to support SSO Token exchanges.
     /// </summary>
-    public class TokenExchangeSkillHandler : SkillHandler
+    public class TokenExchangeSkillHandler : CloudSkillHandler
     {
         private const string WaterfallSkillBot = "WaterfallSkillBot";
         private const string ComposerSkillBot = "ComposerSkillBot";
@@ -32,36 +33,31 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
         private readonly SkillConversationIdFactoryBase _conversationIdFactory;
         private readonly ILogger _logger;
         private readonly IConfiguration _configuration;
-        private readonly AuthenticationConfiguration _authConfig;
-        private readonly BotFrameworkAuthentication _botAuth;
+        private readonly BotFrameworkAuthentication _auth;
 
         public TokenExchangeSkillHandler(
             BotAdapter adapter,
             IBot bot,
             IConfiguration configuration,
-            ICredentialProvider credentialProvider,
             SkillConversationIdFactoryBase conversationIdFactory,
-            AuthenticationConfiguration authConfig,
-            BotFrameworkAuthentication botAuth,
+            BotFrameworkAuthentication auth,
             SkillsConfiguration skillsConfig,
-            IChannelProvider channelProvider = null,
             ILogger<TokenExchangeSkillHandler> logger = null)
-            : base(adapter, bot, conversationIdFactory, credentialProvider, authConfig, channelProvider, logger)
+            : base(adapter, bot, conversationIdFactory, auth, logger)
         {
-            _adapter = adapter;
-
-            _configuration = configuration;
-            _botAuth = botAuth;
-            _authConfig = authConfig;
+            _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
+            _auth = auth ?? throw new ArgumentNullException(nameof(auth));
             _conversationIdFactory = conversationIdFactory;
             _skillsConfig = skillsConfig ?? new SkillsConfiguration(configuration);
+            _configuration = configuration;
+
             _botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-            _logger = logger;
+            _logger = logger ?? NullLogger<TokenExchangeSkillHandler>.Instance;
         }
 
         protected override async Task<ResourceResponse> OnSendToConversationAsync(ClaimsIdentity claimsIdentity, string conversationId, Activity activity, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (await InterceptOAuthCards(claimsIdentity, activity).ConfigureAwait(false))
+            if (await InterceptOAuthCards(claimsIdentity, activity, cancellationToken).ConfigureAwait(false))
             {
                 return new ResourceResponse(Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
             }
@@ -71,7 +67,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
 
         protected override async Task<ResourceResponse> OnReplyToActivityAsync(ClaimsIdentity claimsIdentity, string conversationId, string activityId, Activity activity, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (await InterceptOAuthCards(claimsIdentity, activity).ConfigureAwait(false))
+            if (await InterceptOAuthCards(claimsIdentity, activity, cancellationToken).ConfigureAwait(false))
             {
                 return new ResourceResponse(Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
             }
@@ -91,60 +87,60 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
             return _skillsConfig.Skills.Values.FirstOrDefault(s => string.Equals(s.AppId, appId, StringComparison.InvariantCultureIgnoreCase));
         }
 
-        private async Task<bool> InterceptOAuthCards(ClaimsIdentity claimsIdentity, Activity activity)
+        private async Task<bool> InterceptOAuthCards(ClaimsIdentity claimsIdentity, Activity activity, CancellationToken cancellationToken)
         {
             var oauthCardAttachment = activity.Attachments?.FirstOrDefault(a => a?.ContentType == OAuthCard.ContentType);
-            if (oauthCardAttachment != null)
+            if (oauthCardAttachment == null)
             {
-                var targetSkill = GetCallingSkill(claimsIdentity);
-                if (targetSkill != null)
+                return false;
+            }
+
+            var targetSkill = GetCallingSkill(claimsIdentity);
+            if (targetSkill == null)
+            {
+                return false;
+            }
+
+            var oauthCard = ((JObject)oauthCardAttachment.Content).ToObject<OAuthCard>();
+            if (string.IsNullOrWhiteSpace(oauthCard?.TokenExchangeResource?.Uri))
+            {
+                return false;
+            }
+
+            using var tokenClient = await _auth.CreateUserTokenClientAsync(claimsIdentity, cancellationToken).ConfigureAwait(false);
+            using var context = new TurnContext(_adapter, activity);
+            context.TurnState.Add<IIdentity>(BotAdapter.BotIdentityKey, claimsIdentity);
+
+            // We need to know what connection name to use for the token exchange so we figure that out here
+            var connectionName = targetSkill.Id.Contains(WaterfallSkillBot) || targetSkill.Id.Contains(ComposerSkillBot) ? _configuration.GetSection("SsoConnectionName").Value : _configuration.GetSection("SsoConnectionNameTeams").Value;
+
+            // AAD token exchange
+            try
+            {
+                var result = await tokenClient.ExchangeTokenAsync(
+                    activity.Recipient.Id,
+                    connectionName,
+                    activity.ChannelId,
+                    new TokenExchangeRequest { Uri = oauthCard.TokenExchangeResource.Uri },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (!string.IsNullOrEmpty(result?.Token))
                 {
-                    var oauthCard = ((JObject)oauthCardAttachment.Content).ToObject<OAuthCard>();
-
-                    if (!string.IsNullOrWhiteSpace(oauthCard?.TokenExchangeResource?.Uri))
-                    {
-                        using (var context = new TurnContext(_adapter, activity))
-                        {
-                            context.TurnState.Add<IIdentity>("BotIdentity", claimsIdentity);
-
-                            // We need to know what connection name to use for the token exchange so we figure that out here
-                            var connectionName = targetSkill.Id.Contains(WaterfallSkillBot) || targetSkill.Id.Contains(ComposerSkillBot) ? _configuration.GetSection("SsoConnectionName").Value : _configuration.GetSection("SsoConnectionNameTeams").Value;
-
-                            // AAD token exchange
-                            try
-                            {
-                                var tokenClient = await _botAuth.CreateUserTokenClientAsync(claimsIdentity, CancellationToken.None).ConfigureAwait(false);
-                                var result = await tokenClient.ExchangeTokenAsync(
-                                    activity.Recipient.Id,
-                                    connectionName,
-                                    activity.ChannelId,
-                                    new TokenExchangeRequest { Uri = oauthCard.TokenExchangeResource.Uri },
-                                    CancellationToken.None).ConfigureAwait(false);
-
-                                if (!string.IsNullOrEmpty(result?.Token))
-                                {
-                                    // If token above is null, then SSO has failed and hence we return false.
-                                    // If not, send an invoke to the skill with the token. 
-                                    return await SendTokenExchangeInvokeToSkillAsync(activity, oauthCard.TokenExchangeResource.Id, result.Token, oauthCard.ConnectionName, targetSkill, default).ConfigureAwait(false);
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                // Show oauth card if token exchange fails.
-                                _logger.LogWarning("Unable to exchange token.", ex);
-                                return false;
-                            }
-
-                            return false;
-                        }
-                    }
+                    // If token above is null, then SSO has failed and hence we return false.
+                    // If not, send an invoke to the skill with the token. 
+                    return await SendTokenExchangeInvokeToSkill(activity, oauthCard.TokenExchangeResource.Id, result.Token, oauthCard.ConnectionName, targetSkill, default).ConfigureAwait(false);
                 }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Show oauth card if token exchange fails.
+                _logger.LogWarning("Unable to exchange token.", ex);
             }
 
             return false;
         }
 
-        private async Task<bool> SendTokenExchangeInvokeToSkillAsync(Activity incomingActivity, string id, string token, string connectionName, BotFrameworkSkill targetSkill, CancellationToken cancellationToken)
+        private async Task<bool> SendTokenExchangeInvokeToSkill(Activity incomingActivity, string id, string token, string connectionName, BotFrameworkSkill targetSkill, CancellationToken cancellationToken)
         {
             var activity = incomingActivity.CreateReply();
             activity.Type = ActivityTypes.Invoke;
@@ -158,13 +154,14 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
 
             var skillConversationReference = await _conversationIdFactory.GetSkillConversationReferenceAsync(incomingActivity.Conversation.Id, cancellationToken).ConfigureAwait(false);
             activity.Conversation = skillConversationReference.ConversationReference.Conversation;
+            activity.ServiceUrl = skillConversationReference.ConversationReference.ServiceUrl;
 
             // route the activity to the skill
-            using var client = _botAuth.CreateBotFrameworkClient();
+            using var client = _auth.CreateBotFrameworkClient();
             var response = await client.PostActivityAsync(_botId, targetSkill.AppId, targetSkill.SkillEndpoint, _skillsConfig.SkillHostEndpoint, incomingActivity.Conversation.Id, activity, cancellationToken);
-            
+
             // Check response status: true if success, false if failure
-            return response.Status >= 200 && response.Status <= 299;
+            return response.IsSuccessStatusCode();
         }
     }
 }

--- a/Bots/DotNet/WaterfallHostBot/appsettings.json
+++ b/Bots/DotNet/WaterfallHostBot/appsettings.json
@@ -8,8 +8,10 @@
   },
   "AllowedHosts": "*",
 
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "SsoConnectionName": "",
   "SsoConnectionNameTeams": "",
   "SkillHostEndpoint": "http://localhost:35020/api/skills/",

--- a/Bots/DotNet/WaterfallSkillBot/Controllers/SkillController.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Controllers/SkillController.cs
@@ -13,13 +13,13 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.
-    /// This example uses the <see cref="SkillHandler"/> that is registered as a <see cref="ChannelServiceHandler"/> in startup.cs.
+    /// This example uses the <see cref="CloudSkillHandler"/> that is registered as a <see cref="ChannelServiceHandlerBase"/> in startup.cs.
     /// </summary>
     [ApiController]
     [Route("api/skills")]
     public class SkillController : ChannelServiceController
     {
-        public SkillController(ChannelServiceHandler handler)
+        public SkillController(ChannelServiceHandlerBase handler)
             : base(handler)
         {
         }

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
@@ -32,10 +31,13 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
     public class ActivityRouterDialog : ComponentDialog
     {
         private static readonly string _echoSkill = "EchoSkill";
+        private readonly BotFrameworkAuthentication _auth;
 
-        public ActivityRouterDialog(IConfiguration configuration, IHttpContextAccessor httpContextAccessor, ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient, ConcurrentDictionary<string, ContinuationParameters> continuationParametersStore)
+        public ActivityRouterDialog(BotFrameworkAuthentication auth, IConfiguration configuration, IHttpContextAccessor httpContextAccessor, ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, ConcurrentDictionary<string, ContinuationParameters> continuationParametersStore)
             : base(nameof(ActivityRouterDialog))
         {
+            _auth = auth ?? throw new ArgumentNullException(nameof(auth));
+
             AddDialog(new CardDialog(httpContextAccessor));
             AddDialog(new MessageWithAttachmentDialog(new Uri($"{httpContextAccessor.HttpContext.Request.Scheme}://{httpContextAccessor.HttpContext.Request.Host.Value}")));    
             AddDialog(new WaitForProactiveDialog(httpContextAccessor, continuationParametersStore));
@@ -45,7 +47,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
             AddDialog(new DeleteDialog());
             AddDialog(new UpdateDialog());
 
-            AddDialog(CreateEchoSkillDialog(conversationState, conversationIdFactory, skillClient, configuration));
+            AddDialog(CreateEchoSkillDialog(conversationState, conversationIdFactory, configuration));
 
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[] { ProcessActivityAsync }));
 
@@ -53,7 +55,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
             InitialDialogId = nameof(WaterfallDialog);
         }
 
-        private static SkillDialog CreateEchoSkillDialog(ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient, IConfiguration configuration)
+        private SkillDialog CreateEchoSkillDialog(ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, IConfiguration configuration)
         {
             var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
 
@@ -69,14 +71,13 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
             {
                 BotId = botId,
                 ConversationIdFactory = conversationIdFactory,
-                SkillClient = skillClient,
+                SkillClient = _auth.CreateBotFrameworkClient(),
                 SkillHostEndpoint = new Uri(skillHostEndpoint),
                 ConversationState = conversationState,
                 Skill = skillInfo
             };
-            var echoSkillDialog = new SkillDialog(skillDialogOptions);
+            var echoSkillDialog = new SkillDialog(skillDialogOptions, _echoSkill);
 
-            echoSkillDialog.Id = _echoSkill;
             return echoSkillDialog;
         }
 

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillDialog.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
@@ -54,8 +55,9 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Sso
         private async Task<List<Choice>> GetPromptChoicesAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var promptChoices = new List<Choice>();
-            var adapter = (IUserTokenProvider)stepContext.Context.Adapter;
-            var token = await adapter.GetUserTokenAsync(stepContext.Context, _connectionName, null, cancellationToken);
+            var userId = stepContext.Context.Activity?.From?.Id;
+            var userTokenClient = stepContext.Context.TurnState.Get<UserTokenClient>();
+            var token = await userTokenClient.GetUserTokenAsync(userId, _connectionName, stepContext.Context.Activity?.ChannelId, null, cancellationToken);
 
             if (token == null)
             {
@@ -75,6 +77,8 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Sso
         private async Task<DialogTurnResult> HandleActionStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var action = ((FoundChoice)stepContext.Result).Value.ToLowerInvariant();
+            var userId = stepContext.Context.Activity?.From?.Id;
+            var userTokenClient = stepContext.Context.TurnState.Get<UserTokenClient>();
 
             switch (action)
             {
@@ -82,14 +86,12 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Sso
                     return await stepContext.BeginDialogAsync(nameof(SsoSkillSignInDialog), null, cancellationToken);
 
                 case "logout":
-                    var adapter = (IUserTokenProvider)stepContext.Context.Adapter;
-                    await adapter.SignOutUserAsync(stepContext.Context, _connectionName, cancellationToken: cancellationToken);
+                    await userTokenClient.SignOutUserAsync(userId, _connectionName, stepContext.Context.Activity?.ChannelId, cancellationToken);
                     await stepContext.Context.SendActivityAsync("You have been signed out.", cancellationToken: cancellationToken);
                     return await stepContext.NextAsync(cancellationToken: cancellationToken);
 
                 case "show token":
-                    var tokenProvider = (IUserTokenProvider)stepContext.Context.Adapter;
-                    var token = await tokenProvider.GetUserTokenAsync(stepContext.Context, _connectionName, null, cancellationToken);
+                    var token = await userTokenClient.GetUserTokenAsync(userId, _connectionName, stepContext.Context.Activity?.ChannelId, null, cancellationToken);
                     if (token == null)
                     {
                         await stepContext.Context.SendActivityAsync("User has no cached token.", cancellationToken: cancellationToken);

--- a/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillSignInDialog.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Dialogs/Sso/SsoSkillSignInDialog.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Sso
 {

--- a/Bots/DotNet/WaterfallSkillBot/Startup.cs
+++ b/Bots/DotNet/WaterfallSkillBot/Startup.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Bots;
@@ -37,8 +36,6 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot
             services.AddControllers()
                 .AddNewtonsoftJson();
 
-            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
-
             services.AddSingleton(sp =>
             {
                 // AllowedCallers is the setting in the appsettings.json file that consists of the list of parent bot IDs that are allowed to access the skill.
@@ -65,9 +62,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot
             // Register the skills conversation ID factory, the client and the request handler.
             services.AddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();
 
-            services.AddHttpClient<SkillHttpClient>();
-
-            services.AddSingleton<ChannelServiceHandler, SkillHandler>();
+            services.AddSingleton<ChannelServiceHandlerBase, CloudSkillHandler>();
 
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
             services.AddSingleton<IStorage, MemoryStorage>();

--- a/Bots/DotNet/WaterfallSkillBot/appsettings.json
+++ b/Bots/DotNet/WaterfallSkillBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "ConnectionName": "TestOAuthProvider",
   "SsoConnectionName": "",
   "ChannelService": "",


### PR DESCRIPTION
Addresses # 548

## Description
This PR updates the .NET bots to support SingleTenant and MSI authentication types.

### Detailed Changes
- Updated the following bots based on the implementation in the [skills samples](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore/81.skills-skilldialog):
   - SimpleHostBot
   - EchoSkillBot
   - WaterfallHostBot
   - WaterfallSkillBot
- Updated the SSO implementation in the Waterfall bots to work with CloudAdapter.

## Testing
Here we can see the Waterfall host and skill bots working with the three app types.
![image](https://user-images.githubusercontent.com/44245136/160929425-5d1cff36-1885-4722-bb7a-e64d74c88883.png)
