### PR TITLE
[#548] Add new Standalone/Authentication tests

### DIFF
--- a/Tests/Functional/Common/TestCase.cs
+++ b/Tests/Functional/Common/TestCase.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SkillFunctionalTests.Common
+{
+    public class TestCase<TBot>
+    {
+        public string Channel { get; set; }
+
+        public TBot Bot { get; set; }
+
+        public string Script { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Script}, {Bot}, {Channel}";
+        }
+    }
+}

--- a/Tests/Functional/Common/TestCaseDataObject.cs
+++ b/Tests/Functional/Common/TestCaseDataObject.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Newtonsoft.Json;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Common
+{
+    public class TestCaseDataObject<TClass> : IXunitSerializable
+    {
+        private const string TestObjectKey = "TestObjectKey";
+        private string _testObject;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestCaseDataObject{TClass}"/> class.
+        /// </summary>
+        public TestCaseDataObject()
+        {
+            // Note: This empty constructor is needed by the serializer.
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestCaseDataObject{TClass}"/> class.
+        /// </summary>
+        /// <param name="testData">An object with the data to be used in the test.</param>
+        public TestCaseDataObject(object testData)
+        {
+            _testObject = JsonConvert.SerializeObject(testData);
+        }
+
+        /// <summary>
+        /// Used by XUnit.net for deserialization.
+        /// </summary>
+        /// <param name="serializationInfo">A parameter used by XUnit.net.</param>
+        public void Deserialize(IXunitSerializationInfo serializationInfo)
+        {
+            _testObject = serializationInfo.GetValue<string>(TestObjectKey);
+        }
+
+        /// <summary>
+        /// Used by XUnit.net for serialization.
+        /// </summary>
+        /// <param name="serializationInfo">A parameter used by XUnit.net.</param>
+        public void Serialize(IXunitSerializationInfo serializationInfo)
+        {
+            serializationInfo.AddValue(TestObjectKey, _testObject);
+        }
+
+        /// <summary>
+        /// Gets the test data object for the specified .Net type.
+        /// </summary>
+        /// <returns>The test object instance.</returns>
+        public TClass GetObject()
+        {
+            return JsonConvert.DeserializeObject<TClass>(_testObject);
+        }
+
+        public override string ToString()
+        {
+            try
+            {
+                return GetObject().ToString();
+            }
+            catch (Exception)
+            {
+                return base.ToString();
+            }
+        }
+    }
+}

--- a/Tests/Functional/FunctionalTests.csproj
+++ b/Tests/Functional/FunctionalTests.csproj
@@ -51,10 +51,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Standalone\" />
-  </ItemGroup>
-
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties />

--- a/Tests/Functional/ScriptTestBase.cs
+++ b/Tests/Functional/ScriptTestBase.cs
@@ -6,6 +6,8 @@ using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SkillFunctionalTests.Skills.Common;
+using SkillFunctionalTests.Standalone.Authentication;
+using SkillFunctionalTests.Standalone.Common;
 using TranscriptTestRunner.TestClients;
 using Xunit.Abstractions;
 
@@ -35,6 +37,7 @@ namespace SkillFunctionalTests
 
             TestRequestTimeout = int.Parse(configuration["TestRequestTimeout"]);
             TestClientOptions = configuration.GetSection("HostBotClientOptions").Get<Dictionary<HostBot, DirectLineTestClientOptions>>();
+            TestAuthClientOptions = configuration.GetSection("AuthBotClientOptions").Get<Dictionary<Bot, Dictionary<MicrosoftAppType, DirectLineTestClientOptions>>>();
             ThinkTime = int.Parse(configuration["ThinkTime"]);
         }
 
@@ -44,6 +47,8 @@ namespace SkillFunctionalTests
         };
 
         public Dictionary<HostBot, DirectLineTestClientOptions> TestClientOptions { get; }
+
+        public Dictionary<Bot, Dictionary<MicrosoftAppType, DirectLineTestClientOptions>> TestAuthClientOptions { get; }
 
         public ILogger Logger { get; }
 

--- a/Tests/Functional/ScriptTestBase.cs
+++ b/Tests/Functional/ScriptTestBase.cs
@@ -38,6 +38,11 @@ namespace SkillFunctionalTests
             ThinkTime = int.Parse(configuration["ThinkTime"]);
         }
 
+        public static List<string> Channels { get; } = new List<string>
+        {
+            Microsoft.Bot.Connector.Channels.Directline
+        };
+
         public Dictionary<HostBot, DirectLineTestClientOptions> TestClientOptions { get; }
 
         public ILogger Logger { get; }

--- a/Tests/Functional/Skills/CardActions/CardActionsTests.cs
+++ b/Tests/Functional/Skills/CardActions/CardActionsTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -28,8 +27,6 @@ namespace SkillFunctionalTests.Skills.CardActions
 
         public static IEnumerable<object[]> TestCases()
         {
-            var channelIds = new List<string> { Channels.Directline };
-            
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
@@ -88,7 +85,7 @@ namespace SkillFunctionalTests.Skills.CardActions
                 return false;
             }
 
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
+            var testCases = testCaseBuilder.BuildTestCases(Channels, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Skills/FileUpload/FileUploadTests.cs
+++ b/Tests/Functional/Skills/FileUpload/FileUploadTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -29,8 +28,6 @@ namespace SkillFunctionalTests.Skills.FileUpload
 
         public static IEnumerable<object[]> TestCases()
         {
-            var channelIds = new List<string> { Channels.Directline };
-
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
@@ -59,7 +56,7 @@ namespace SkillFunctionalTests.Skills.FileUpload
             };
 
             var testCaseBuilder = new TestCaseBuilder();
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+            var testCases = testCaseBuilder.BuildTestCases(Channels, deliverModes, hostBots, targetSkills, scripts);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Skills/MessageWithAttachment/MessageWithAttachmentTests.cs
+++ b/Tests/Functional/Skills/MessageWithAttachment/MessageWithAttachmentTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -28,7 +27,6 @@ namespace SkillFunctionalTests.Skills.MessageWithAttachment
 
         public static IEnumerable<object[]> TestCases()
         {
-            var channelIds = new List<string> { Channels.Directline };
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
@@ -58,7 +56,7 @@ namespace SkillFunctionalTests.Skills.MessageWithAttachment
 
             var testCaseBuilder = new TestCaseBuilder();
 
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+            var testCases = testCaseBuilder.BuildTestCases(Channels, deliverModes, hostBots, targetSkills, scripts);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Skills/ProactiveMessages/ProactiveTests.cs
+++ b/Tests/Functional/Skills/ProactiveMessages/ProactiveTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -29,7 +28,6 @@ namespace SkillFunctionalTests.Skills.ProactiveMessages
 
         public static IEnumerable<object[]> TestCases()
         {
-            var channelIds = new List<string> { Channels.Directline };
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
@@ -61,7 +59,7 @@ namespace SkillFunctionalTests.Skills.ProactiveMessages
 
             var testCaseBuilder = new TestCaseBuilder();
 
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+            var testCases = testCaseBuilder.BuildTestCases(Channels, deliverModes, hostBots, targetSkills, scripts);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Skills/SignIn/SignInTests.cs
+++ b/Tests/Functional/Skills/SignIn/SignInTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -29,7 +28,6 @@ namespace SkillFunctionalTests.Skills.SignIn
 
         public static IEnumerable<object[]> TestCases()
         {
-            var channelIds = new List<string> { Channels.Directline };
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
@@ -61,7 +59,7 @@ namespace SkillFunctionalTests.Skills.SignIn
 
             var testCaseBuilder = new TestCaseBuilder();
 
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+            var testCases = testCaseBuilder.BuildTestCases(Channels, deliverModes, hostBots, targetSkills, scripts);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Skills/SingleTurn/EchoTests.cs
+++ b/Tests/Functional/Skills/SingleTurn/EchoTests.cs
@@ -28,7 +28,6 @@ namespace SkillFunctionalTests.Skills.SingleTurn
 
         public static IEnumerable<object[]> TestCases()
         {
-            var channelIds = new List<string> { Channels.Directline };
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
@@ -72,7 +71,7 @@ namespace SkillFunctionalTests.Skills.SingleTurn
                 return false;
             }
 
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
+            var testCases = testCaseBuilder.BuildTestCases(Channels, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Skills/Sso/SsoTests.cs
+++ b/Tests/Functional/Skills/Sso/SsoTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -27,7 +26,6 @@ namespace SkillFunctionalTests.Skills.Sso
 
         public static IEnumerable<object[]> TestCases()
         {
-            var channelIds = new List<string> { Channels.Directline };
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
@@ -55,7 +53,7 @@ namespace SkillFunctionalTests.Skills.Sso
 
             var testCaseBuilder = new TestCaseBuilder();
 
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+            var testCases = testCaseBuilder.BuildTestCases(Channels, deliverModes, hostBots, targetSkills, scripts);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/Functional/Standalone/Authentication/AuthTestBase.cs
+++ b/Tests/Functional/Standalone/Authentication/AuthTestBase.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SkillFunctionalTests.Common;
+using SkillFunctionalTests.Standalone.Common;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Standalone.Authentication
+{
+    public class AuthTestBase : ScriptTestBase
+    {
+        public AuthTestBase(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static List<MicrosoftAppType> AppTypes { get; } = new List<MicrosoftAppType>
+        {
+            MicrosoftAppType.MultiTenant,
+            MicrosoftAppType.SingleTenant,
+            MicrosoftAppType.UserAssignedMsi
+        };
+
+        public static List<Bot> Bots { get; } = new List<Bot>
+        {
+            Bot.EchoBotDotNet,
+            Bot.EchoBotJS,
+        };
+
+        public static IEnumerable<object[]> BuildTestCases(
+            List<string> scripts,
+            List<Bot> bots = default,
+            List<string> channels = default,
+            List<MicrosoftAppType> appTypes = default,
+            Func<AuthTestCase, bool> exclude = default)
+        {
+            var cases = from channel in channels ?? Channels
+                        from appType in appTypes ?? AppTypes
+                        from bot in bots ?? Bots
+                        from script in scripts
+                        select new AuthTestCase
+                        {
+                            Channel = channel,
+                            AppType = appType,
+                            Bot = bot,
+                            Script = script
+                        };
+
+            return cases
+                .Where(e => exclude == null || !exclude(e))
+                .Select(e => new object[] { new TestCaseDataObject<AuthTestCase>(e) });
+        }
+    }
+}

--- a/Tests/Functional/Standalone/Authentication/AuthTestCase.cs
+++ b/Tests/Functional/Standalone/Authentication/AuthTestCase.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using SkillFunctionalTests.Common;
+using SkillFunctionalTests.Standalone.Common;
+
+namespace SkillFunctionalTests.Standalone.Authentication
+{
+    public class AuthTestCase : TestCase<Bot>
+    {
+        public MicrosoftAppType AppType { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Script}, {Bot}, {AppType}, {Channel}";
+        }
+    }
+}

--- a/Tests/Functional/Standalone/Authentication/AuthTests.cs
+++ b/Tests/Functional/Standalone/Authentication/AuthTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.Standalone.Authentication
+{
+    [Trait("TestCategory", "Authentication")]
+    public class AuthTests : AuthTestBase
+    {
+        private static readonly List<string> Scripts = new List<string>
+        {
+            "Echo.json"
+        };
+
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Standalone/Authentication/TestScripts";
+
+        public AuthTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases() => BuildTestCases(scripts: Scripts);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject<AuthTestCase> testData)
+        {
+            var authTestCase = testData.GetObject();
+            Logger.LogInformation(JsonConvert.SerializeObject(authTestCase, Formatting.Indented));
+
+            var options = TestAuthClientOptions[authTestCase.Bot][authTestCase.AppType];
+
+            var runner = new XUnitTestRunner(new TestClientFactory(authTestCase.Channel, options, Logger).GetTestClient(), TestRequestTimeout, ThinkTime, Logger);
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, authTestCase.Script));
+        }
+    }
+}

--- a/Tests/Functional/Standalone/Authentication/MicrosoftAppType.cs
+++ b/Tests/Functional/Standalone/Authentication/MicrosoftAppType.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SkillFunctionalTests.Standalone.Authentication
+{
+    public enum MicrosoftAppType
+    {
+        /// <summary>
+        /// MultiTenant app which uses botframework.com tenant to acquire tokens.
+        /// </summary>
+        MultiTenant,
+
+        /// <summary>
+        /// SingleTenant app which uses the bot's host tenant to acquire tokens.
+        /// </summary>
+        SingleTenant,
+
+        /// <summary>
+        /// App with a user assigned Managed Identity (MSI), which will be used as the AppId for token acquisition.
+        /// </summary>
+        UserAssignedMsi
+    }
+}

--- a/Tests/Functional/Standalone/Authentication/TestScripts/Echo.json
+++ b/Tests/Functional/Standalone/Authentication/TestScripts/Echo.json
@@ -1,0 +1,77 @@
+﻿{
+  "items": [
+    {
+      "type": "conversationUpdate",
+      "role": "user"
+    },
+    {
+      "type": "message",
+      "role": "bot",
+      "text": "Welcome to the echo skill bot. \n\nThis is a skill, you will need to call it from another bot to use it.",
+      "assertions": [
+        "type == 'message'",
+        "from.role == 'bot'",
+        "recipient.role == 'user'",
+        "text == 'Welcome to the echo skill bot. \n\nThis is a skill, you will need to call it from another bot to use it.'",
+        "speak == 'Welcome to the echo skill bot. This is a skill, you will need to call it from another bot to use it.'",
+        "inputHint == 'acceptingInput'"
+      ]
+    },
+    {
+      "type": "message",
+      "role": "user",
+      "text": "Hello!"
+    },
+    {
+      "type": "message",
+      "role": "bot",
+      "text": "Echo: Hello!",
+      "assertions": [
+        "type == 'message'",
+        "from.role == 'bot'",
+        "recipient.role == 'user'",
+        "text == 'Echo: Hello!'",
+        "inputHint == 'acceptingInput'"
+      ]
+    },
+    {
+      "type": "message",
+      "role": "bot",
+      "text": "Say \"end\" or \"stop\" and I'll end the conversation and back to the parent.",
+      "assertions": [
+        "type == 'message'",
+        "from.role == 'bot'",
+        "recipient.role == 'user'",
+        "text == 'Say \"end\" or \"stop\" and I\\'ll end the conversation and back to the parent.'",
+        "inputHint == 'acceptingInput'"
+      ]
+    },
+    {
+      "type": "message",
+      "role": "user",
+      "text": "end"
+    },
+    {
+      "type": "message",
+      "role": "bot",
+      "text": "Ending conversation from the skill...",
+      "assertions": [
+        "type == 'message'",
+        "from.role == 'bot'",
+        "recipient.role == 'user'",
+        "text == 'Ending conversation from the skill...'",
+        "inputHint == 'acceptingInput'"
+      ]
+    },
+    {
+      "type": "endOfConversation",
+      "role": "bot",
+      "assertions": [
+        "type == 'endOfConversation'",
+        "from.role == 'bot'",
+        "recipient.role == 'user'",
+        "code == 'completedSuccessfully'"
+      ]
+    }
+  ]
+}

--- a/Tests/Functional/Standalone/Authentication/TestScripts/Echo.transcript
+++ b/Tests/Functional/Standalone/Authentication/TestScripts/Echo.transcript
@@ -1,0 +1,221 @@
+﻿[
+  {
+    "type": "conversationUpdate",
+    "membersAdded": [
+      {
+        "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+        "name": "Bot"
+      },
+      {
+        "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+        "name": "User"
+      }
+    ],
+    "membersRemoved": [],
+    "channelId": "emulator",
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "id": "8b402420-b033-11ec-9994-05b504759836",
+    "localTimestamp": "2022-03-30T11:13:16-03:00",
+    "recipient": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "timestamp": "2022-03-30T14:13:16.770Z",
+    "from": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "name": "User",
+      "role": "user"
+    },
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io"
+  },
+  {
+    "type": "message",
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io",
+    "channelId": "emulator",
+    "from": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "recipient": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "role": "user"
+    },
+    "text": "Welcome to the echo skill bot. \n\nThis is a skill, you will need to call it from another bot to use it.",
+    "speak": "Welcome to the echo skill bot. This is a skill, you will need to call it from another bot to use it.",
+    "inputHint": "acceptingInput",
+    "attachments": [],
+    "entities": [],
+    "replyToId": "8b402420-b033-11ec-9994-05b504759836",
+    "id": "9117f5d0-b033-11ec-9994-05b504759836",
+    "localTimestamp": "2022-03-30T11:13:26-03:00",
+    "timestamp": "2022-03-30T14:13:26.573Z"
+  },
+  {
+    "channelData": {
+      "clientActivityID": "16486496570828wgjavppa24",
+      "clientTimestamp": "2022-03-30T14:14:17.082Z"
+    },
+    "text": "Hello!",
+    "textFormat": "plain",
+    "type": "message",
+    "channelId": "emulator",
+    "from": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "name": "User",
+      "role": "user"
+    },
+    "localTimestamp": "2022-03-30T11:14:17-03:00",
+    "localTimezone": "America/Buenos_Aires",
+    "timestamp": "2022-03-30T14:14:17.149Z",
+    "entities": [
+      {
+        "requiresBotState": true,
+        "supportsListening": true,
+        "supportsTts": true,
+        "type": "ClientCapabilities"
+      }
+    ],
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "id": "af3d3ed0-b033-11ec-9994-05b504759836",
+    "recipient": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io"
+  },
+  {
+    "type": "message",
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io",
+    "channelId": "emulator",
+    "from": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "recipient": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "role": "user"
+    },
+    "text": "Echo: Hello!",
+    "inputHint": "acceptingInput",
+    "attachments": [],
+    "entities": [],
+    "replyToId": "af3d3ed0-b033-11ec-9994-05b504759836",
+    "id": "afd6bfb0-b033-11ec-9994-05b504759836",
+    "localTimestamp": "2022-03-30T11:14:18-03:00",
+    "timestamp": "2022-03-30T14:14:18.155Z"
+  },
+  {
+    "type": "message",
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io",
+    "channelId": "emulator",
+    "from": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "recipient": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "role": "user"
+    },
+    "text": "Say \"end\" or \"stop\" and I'll end the conversation and back to the parent.",
+    "inputHint": "acceptingInput",
+    "attachments": [],
+    "entities": [],
+    "replyToId": "af3d3ed0-b033-11ec-9994-05b504759836",
+    "id": "b024dfb0-b033-11ec-9994-05b504759836",
+    "localTimestamp": "2022-03-30T11:14:18-03:00",
+    "timestamp": "2022-03-30T14:14:18.667Z"
+  },
+  {
+    "channelData": {
+      "clientActivityID": "16486496609418c25iryra08",
+      "clientTimestamp": "2022-03-30T14:14:20.941Z"
+    },
+    "text": "end",
+    "textFormat": "plain",
+    "type": "message",
+    "channelId": "emulator",
+    "from": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "name": "User",
+      "role": "user"
+    },
+    "localTimestamp": "2022-03-30T11:14:20-03:00",
+    "localTimezone": "America/Buenos_Aires",
+    "timestamp": "2022-03-30T14:14:20.989Z",
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "id": "b1872ed0-b033-11ec-9994-05b504759836",
+    "recipient": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io"
+  },
+  {
+    "type": "message",
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io",
+    "channelId": "emulator",
+    "from": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "recipient": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "role": "user"
+    },
+    "text": "Ending conversation from the skill...",
+    "inputHint": "acceptingInput",
+    "attachments": [],
+    "entities": [],
+    "replyToId": "b1872ed0-b033-11ec-9994-05b504759836",
+    "id": "b223e400-b033-11ec-9994-05b504759836",
+    "localTimestamp": "2022-03-30T11:14:22-03:00",
+    "timestamp": "2022-03-30T14:14:22.015Z"
+  },
+  {
+    "type": "endOfConversation",
+    "serviceUrl": "https://1b13-2800-810-472-14d5-2546-a279-3841-68d5.ngrok.io",
+    "channelId": "emulator",
+    "from": {
+      "id": "2ce182c0-b033-11ec-94e2-958f4b4c435a",
+      "name": "Bot",
+      "role": "bot"
+    },
+    "conversation": {
+      "id": "8b1df620-b033-11ec-94e2-958f4b4c435a|livechat"
+    },
+    "recipient": {
+      "id": "e1618b1a-5adb-45d7-94bc-84fffc849b73",
+      "role": "user"
+    },
+    "replyToId": "b1872ed0-b033-11ec-9994-05b504759836",
+    "code": "completedSuccessfully",
+    "id": "b27697e0-b033-11ec-9994-05b504759836",
+    "localTimestamp": "2022-03-30T11:14:22-03:00",
+    "timestamp": "2022-03-30T14:14:22.558Z"
+  }
+]

--- a/Tests/Functional/Standalone/Common/Bot.cs
+++ b/Tests/Functional/Standalone/Common/Bot.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SkillFunctionalTests.Standalone.Common
+{
+    public enum Bot
+    {
+        /// <summary>
+        /// Echo implemented using DotNet 3.1.
+        /// </summary>
+        EchoBotDotNet,
+
+        /// <summary>
+        /// Echo implemented using JS.
+        /// </summary>
+        EchoBotJS
+    }
+}

--- a/Tests/Functional/appsettings.json
+++ b/Tests/Functional/appsettings.json
@@ -7,7 +7,7 @@
   },
 
   "TestRequestTimeout": 180000,
-  "ThinkTime":  500,
+  "ThinkTime": 500,
 
   "HostBotClientOptions": {
     "ComposerHostBotDotNet": {
@@ -41,6 +41,36 @@
     "WaterfallHostBotPython": {
       "BotId": "bffnwaterfallhostbotpython",
       "DirectLineSecret": ""
+    }
+  },
+  "AuthBotClientOptions": {
+    "EchoBotDotNet": {
+      "MultiTenant": {
+        "BotId": "bffnechomultitenantdotnet",
+        "DirectLineSecret": ""
+      },
+      "SingleTenant": {
+        "BotId": "bffnechosingletenantdotnet",
+        "DirectLineSecret": ""
+      },
+      "UserAssignedMsi": {
+        "BotId": "bffnechomsidotnet",
+        "DirectLineSecret": ""
+      }
+    },
+    "EchoBotJS": {
+      "MultiTenant": {
+        "BotId": "bffnechomultitenantjs",
+        "DirectLineSecret": ""
+      },
+      "SingleTenant": {
+        "BotId": "bffnechosingletenantjs",
+        "DirectLineSecret": ""
+      },
+      "UserAssignedMsi": {
+        "BotId": "bffnechomsijs",
+        "DirectLineSecret": ""
+      }
     }
   }
 }


### PR DESCRIPTION
Addresses # 548

## Description
This PR adds new `Authentication` tests to the `Standalone` structure.

### Detailed Changes
- Adds `AuthTestBase` class containing the necessary lists and the build process to construct all the test cases combinations.
- Adds the `MicrosoftAppType` containing the supported types of authentication (MSI, SingleTenant and MultiTenant).
- Adds an `Echo.json` script containing all the steps to run the test.
- Adds a new `Bot` enum list to support these new tests.

## Testing
The following images show the Test Scenarios pipeline continue working as expected.
![imagen](https://user-images.githubusercontent.com/62260472/161064855-965fe50b-6b6b-4b6f-966b-a30e8c923a46.png)
