### PR TITLE
[#503] Improve Transcript Converter performance

### DIFF
--- a/Libraries/TranscriptConverter/ConvertTranscriptHandler.cs
+++ b/Libraries/TranscriptConverter/ConvertTranscriptHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Diagnostics;
 using System.IO;
 using Newtonsoft.Json;
 
@@ -26,17 +27,24 @@ namespace TranscriptConverter
             {
                 try
                 {
-                    Console.WriteLine("{0}: {1}", "Converting source transcript", source);
+                    var rootStopwatch = new Stopwatch();
+                    var stopwatch = new Stopwatch();
+                    rootStopwatch.Start();
+
+                    Console.WriteLine("Reading TranScript file\n  - Path: {0}", source);
 
                     var testScript = Converter.ConvertTranscript(source);
 
-                    Console.WriteLine("Finished conversion");
-
+                    stopwatch.Start();
                     var targetPath = string.IsNullOrEmpty(target) ? source.Replace(".transcript", ".json", StringComparison.InvariantCulture) : target;
 
                     WriteTestScript(testScript, targetPath);
 
-                    Console.WriteLine("{0}: {1}", "Test script saved as", targetPath);
+                    stopwatch.Stop();
+                    Console.WriteLine("Saving TestScript file ({0}ms)\n  - Path: {1}", stopwatch.ElapsedMilliseconds, targetPath);
+
+                    rootStopwatch.Stop();
+                    Console.WriteLine("\nFinished processing ({0}ms)", rootStopwatch.ElapsedMilliseconds);
                 }
                 catch (FileNotFoundException e)
                 {

--- a/Libraries/TranscriptConverter/Converter.cs
+++ b/Libraries/TranscriptConverter/Converter.cs
@@ -13,6 +13,12 @@ namespace TranscriptConverter
 {
     public static class Converter
     {
+        private static readonly HashSet<JTokenType> IgnoreTypes = new HashSet<JTokenType>
+        {
+            JTokenType.Array,
+            JTokenType.Object
+        };
+
         /// <summary>
         /// Converts the transcript into a test script.
         /// </summary>
@@ -54,12 +60,6 @@ namespace TranscriptConverter
                 return null;
             }
 
-            var ignoreTypes = new HashSet<JTokenType>
-            {
-                JTokenType.Array,
-                JTokenType.Object
-            };
-
             static bool ShouldRemove(HashSet<string> processedProps, JProperty prop)
             {
                 var key = prop.Name;
@@ -88,7 +88,7 @@ namespace TranscriptConverter
 
             container.DescendantsAndSelf()
                 .OfType<JProperty>()
-                .Where(prop => !ignoreTypes.Contains(prop.Value.Type))
+                .Where(prop => !IgnoreTypes.Contains(prop.Value.Type))
                 .Where(prop => ShouldRemove(processedProps, prop))
                 .ToList()
                 .ForEach(prop => prop.Remove());
@@ -107,12 +107,6 @@ namespace TranscriptConverter
             {
                 return null;
             }
-
-            var ignoreTypes = new HashSet<JTokenType>
-            {
-                JTokenType.Array,
-                JTokenType.Object
-            };
 
             var ignoreFields = new HashSet<string>
             {
@@ -154,7 +148,7 @@ namespace TranscriptConverter
                 };
             }
 
-            var items = container.Select(obj => MapItem(obj, ignoreTypes, ignoreFields)).ToList();
+            var items = container.Select(obj => MapItem(obj, IgnoreTypes, ignoreFields)).ToList();
 
             return new TestScript(items);
         }

--- a/Libraries/TranscriptConverter/Converter.cs
+++ b/Libraries/TranscriptConverter/Converter.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace TranscriptConverter
@@ -21,43 +20,80 @@ namespace TranscriptConverter
         /// <returns>The test script created.</returns>
         public static TestScript ConvertTranscript(string transcriptPath)
         {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             using var reader = new StreamReader(Path.GetFullPath(transcriptPath));
 
             var transcript = reader.ReadToEnd();
+            var json = JToken.Parse(transcript);
+            var cleanedTranscript = RemoveUndesiredFields(json);
 
-            var cleanedTranscript = RemoveUndesiredFields(transcript);
+            stopwatch.Stop();
+            Console.WriteLine("Removing undesired fields ({0}ms)", stopwatch.ElapsedMilliseconds);
+            stopwatch.Reset();
+            stopwatch.Start();
 
-            return CreateTestScript(cleanedTranscript);
+            var result = CreateTestScript(cleanedTranscript);
+
+            stopwatch.Stop();
+            Console.WriteLine("Creating TestScript ({0}ms)", stopwatch.ElapsedMilliseconds);
+
+            return result;
         }
 
         /// <summary>
-        /// Recursively goes through the json content removing the undesired elements.
+        /// Removes variable fields like IDs, Dates and urls from the transcript file.
         /// </summary>
-        /// <param name="token">The JToken element to process.</param>
-        /// <param name="callback">The recursive function to iterate over the JToken.</param>
-        private static void RemoveFields(JToken token, Func<JProperty, bool> callback)
+        /// <param name="json">The transcript file content.</param>
+        /// <returns>The transcript content without the undesired fields.</returns>
+        private static JToken RemoveUndesiredFields(JToken json)
         {
-            if (!(token is JContainer container))
+            if (!(json is JContainer container))
             {
-                return;
+                return null;
             }
 
-            var removeList = new List<JToken>();
-
-            foreach (var element in container.Children())
+            var ignoreTypes = new HashSet<JTokenType>
             {
-                if (element is JProperty prop && callback(prop))
+                JTokenType.Array,
+                JTokenType.Object
+            };
+
+            static bool ShouldRemove(HashSet<string> processedProps, JProperty prop)
+            {
+                var key = prop.Name;
+                var value = prop.Value.ToString();
+
+                if (processedProps.Contains(key))
                 {
-                    removeList.Add(element);
+                    return true;
                 }
 
-                RemoveFields(element, callback);
+                var result = string.IsNullOrEmpty(value)
+                    || IsDateTime(value)
+                    || IsUrl(value)
+                    || IsBase64Image(value)
+                    || IsId(key, value);
+
+                if (result)
+                {
+                    processedProps.Add(key);
+                }
+
+                return result;
             }
 
-            foreach (var element in removeList)
-            {
-                element.Remove();
-            }
+            var processedProps = new HashSet<string>();
+
+            container.DescendantsAndSelf()
+                .OfType<JProperty>()
+                .Where(prop => !ignoreTypes.Contains(prop.Value.Type))
+                .Where(prop => ShouldRemove(processedProps, prop))
+                .ToList()
+                .ForEach(prop => prop.Remove());
+
+            return container;
         }
 
         /// <summary>
@@ -65,86 +101,62 @@ namespace TranscriptConverter
         /// </summary>
         /// <param name="json">Json containing the transcript's activities.</param>
         /// <returns>The test script created.</returns>
-        private static TestScript CreateTestScript(string json)
+        private static TestScript CreateTestScript(JToken json)
         {
-            var activities = JsonConvert.DeserializeObject<IEnumerable<Activity>>(json);
-            var testScript = new TestScript();
-
-            foreach (var activity in activities)
+            if (!(json is JContainer container))
             {
-                var scriptItem = new TestScriptItem
+                return null;
+            }
+
+            var ignoreTypes = new HashSet<JTokenType>
+            {
+                JTokenType.Array,
+                JTokenType.Object
+            };
+
+            var ignoreFields = new HashSet<string>
+            {
+                "from.name"
+            };
+
+            static string MapAssert(JProperty prop)
+            {
+                var value = prop.Value.Type == JTokenType.String
+                    ? $"'{prop.Value.ToString().Replace("'", "\\'", StringComparison.InvariantCulture)}'"
+                    : prop.Value;
+
+                return $"{prop.Path} == {value}";
+            }
+
+            static TestScriptItem MapItem(JToken obj, HashSet<JTokenType> ignoreTypes, HashSet<string> ignoreFields)
+            {
+                // Detach from the container.
+                var activityJson = JToken.Parse(obj.ToString());
+                var assertions = new List<string>();
+
+                var role = activityJson["from"].Value<string>("role");
+                if (role == "bot")
                 {
-                    Type = activity.Type,
-                    Role = activity.From.Role,
-                    Text = activity.Text
+                    assertions = (activityJson as JContainer)
+                        .DescendantsAndSelf()
+                        .OfType<JProperty>()
+                        .Where(prop => !ignoreTypes.Contains(prop.Value.Type))
+                        .Where(prop => !ignoreFields.Contains(prop.Path))
+                        .Select(MapAssert)
+                        .ToList();
+                }
+
+                return new TestScriptItem(assertions)
+                {
+                    Type = activityJson.Value<string>("type"),
+                    Role = role,
+                    Text = activityJson.Value<string>("text"),
                 };
-
-                if (scriptItem.Role == "bot")
-                {
-                    var assertionsList = CreateAssertionsList(activity);
-
-                    foreach (var assertion in assertionsList)
-                    {
-                        scriptItem.Assertions.Add(assertion);
-                    }
-                }
-
-                testScript.Items.Add(scriptItem);
             }
 
-            return testScript;
-        }
+            var items = container.Select(obj => MapItem(obj, ignoreTypes, ignoreFields)).ToList();
 
-        /// <summary>
-        /// Creates a list of assertions with the activity's properties.
-        /// </summary>
-        /// <param name="activity">The activity to parse as assertions.</param>
-        /// <returns>The list of assertions.</returns>
-        private static IEnumerable<string> CreateAssertionsList(IActivity activity)
-        {
-            var json = JsonConvert.SerializeObject(
-                activity,
-                Formatting.None,
-                new JsonSerializerSettings
-                {
-                    NullValueHandling = NullValueHandling.Ignore
-                });
-
-            var token = JToken.Parse(json);
-            var assertionsList = new List<string>();
-
-            AddAssertions(token, assertionsList);
-
-            return assertionsList;
-        }
-
-        /// <summary>
-        /// Goes over the Jtoken object adding assertions to the list for each property found.
-        /// </summary>
-        /// <param name="token">The JToken object containing the properties.</param>
-        /// <param name="assertionsList">The list of assertions.</param>
-        private static void AddAssertions(JToken token, ICollection<string> assertionsList)
-        {
-            foreach (var property in token)
-            {
-                if (property is JProperty prop && !IsJsonObject(prop.Value.ToString()))
-                {
-                    if (prop.Path == "from.name")
-                    {
-                        continue;
-                    }
-
-                    var value = prop.Value.Type == JTokenType.String
-                        ? $"'{prop.Value.ToString().Replace("'", "\\'", StringComparison.InvariantCulture)}'"
-                        : prop.Value;
-
-                    assertionsList.Add($"{prop.Path} == {value}");
-                }
-                else
-                {
-                    AddAssertions(property, assertionsList);
-                }
-            }
+            return new TestScript(items);
         }
 
         /// <summary>
@@ -202,24 +214,6 @@ namespace TranscriptConverter
         }
 
         /// <summary>
-        /// Checks if a string is a JSON Object.
-        /// </summary>
-        /// <param name="value">The string to check.</param>
-        /// <returns>True if the string is a JSON Object, otherwise, returns false.</returns>
-        private static bool IsJsonObject(string value)
-        {
-            try
-            {
-                var json = JsonConvert.DeserializeObject<JToken>(value);
-                return json != null && (json.Type == JTokenType.Object || json.Type == JTokenType.Array);
-            }
-            catch (JsonException)
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Checks if a string is a DateTime value.
         /// </summary>
         /// <param name="datetime">The string to check.</param>
@@ -228,35 +222,6 @@ namespace TranscriptConverter
         {
             var dateMatch = DateTime.TryParse(datetime, out _);
             return dateMatch;
-        }
-
-        /// <summary>
-        /// Removes variable fields like IDs, Dates and urls from the transcript file.
-        /// </summary>
-        /// <param name="transcript">The transcript file content.</param>
-        /// <returns>The transcript content without the undesired fields.</returns>
-        private static string RemoveUndesiredFields(string transcript)
-        {
-            var token = JToken.Parse(transcript);
-
-            RemoveFields(token, (attr) =>
-            {
-                var name = attr.Name.ToString();
-                var value = attr.Value.ToString();
-
-                if (IsJsonObject(value))
-                {
-                    return false;
-                }
-
-                return string.IsNullOrEmpty(value)
-                    || IsDateTime(value)
-                    || IsUrl(value)
-                    || IsBase64Image(value)
-                    || IsId(name, value);
-            });
-
-            return token.ToString();
         }
     }
 }

--- a/Libraries/TranscriptConverter/TestScript.cs
+++ b/Libraries/TranscriptConverter/TestScript.cs
@@ -12,6 +12,15 @@ namespace TranscriptConverter
     public class TestScript
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TestScript"/> class.
+        /// </summary>
+        /// <param name="items">The sequence of test scripts to perform to validate the bots behavior.</param>
+        public TestScript(List<TestScriptItem> items = default)
+        {
+            Items = items ?? new List<TestScriptItem>();
+        }
+
+        /// <summary>
         /// Gets the test script items.
         /// </summary>
         /// <value>

--- a/Libraries/TranscriptConverter/TestScriptItem.cs
+++ b/Libraries/TranscriptConverter/TestScriptItem.cs
@@ -12,6 +12,15 @@ namespace TranscriptConverter
     public class TestScriptItem
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TestScriptItem"/> class.
+        /// </summary>
+        /// <param name="assertions">The activity assertion collection.</param>
+        public TestScriptItem(List<string> assertions = default)
+        {
+            Assertions = assertions ?? new List<string>();
+        }
+
+        /// <summary>
         /// Gets or sets the activity type.
         /// </summary>
         /// <value>


### PR DESCRIPTION
Addresses # 503

## Description
This PR updates the way the Transcript Convert library works internally from reading the `.transcript` file, identifying and removing undesired fields, and creating the processed TestScript file.
The new conversion process time was improved from a total of **32 seconds** to approximately **1-2 seconds**.

### Detailed Changes
- Added diagnostic logs, improving the output and showing the time it takes each part of the process.
- Refactored the `RemoveUndesiredFields` and `CreateTestScript` methods, making them clearer and performant by removing altogether the use of recursive methods and reducing the amount of time an object is serialized/deserialized.
  - The `RemoveUndesiredFields` method will now combine all the deep JToken nodes into a single list, making it easier and performant to filter the fields to remove, given by the existing conditions (IsId, IsUrl, etc).
  - The `CreateTestScript` method will now convert the Transcript content in the less amount of steps possible without the use of JSON Serialization and Deserialization, which makes the process lower.
  - The overall source code has been reduced considerably after the refactor, removing unnecessary methods used by the previous processes.

## Testing
The following image shows the before and after applying the changes.
![image](https://user-images.githubusercontent.com/62260472/162269385-c83340ef-1bf5-4951-b1b8-684917e2b4d9.png)