### PR TITLE
[#562][DotNet] Add Azure Storage Blobs tests to the test solution

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <RepositoryUrl>https://github.com/microsoft/BotFramework-FunctionalTests</RepositoryUrl>
     <LicenseUrl>https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/LICENSE</LicenseUrl>
     <RepositoryType />
@@ -36,4 +36,22 @@
     <BotBuilderVersion Condition="'$(BotBuilderVersion)' != ''">$(BotBuilderVersion)</BotBuilderVersion>
     <RestoreAdditionalProjectSources>$(BotBuilderRegistry)</RestoreAdditionalProjectSources>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(BotBuilderVersion.Contains('daily'))">
+      <PropertyGroup>
+        <BotBuilderVersionPreview>$(BotBuilderVersion.Replace('daily', 'daily.preview'))</BotBuilderVersionPreview>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(BotBuilderVersion.Contains('rc'))">
+      <PropertyGroup>
+        <BotBuilderVersionPreview>$(BotBuilderVersion).preview</BotBuilderVersionPreview>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <BotBuilderVersionPreview>$(BotBuilderVersion)-preview</BotBuilderVersionPreview>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/Tests.sln
+++ b/Tests.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29806.167
@@ -14,19 +14,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TranscriptConverter", "Libraries\TranscriptConverter\Microsoft.Bot.Builder.Testing.TranscriptConverter.csproj", "{EF963904-79CB-4222-811A-E24B73E5DC1A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing.TranscriptConverter", "Libraries\TranscriptConverter\Microsoft.Bot.Builder.Testing.TranscriptConverter.csproj", "{EF963904-79CB-4222-811A-E24B73E5DC1A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{B5E35C94-0880-4AEB-8F3C-940FECA7A8C7}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{5A0C68F1-6CA7-43D7-8F01-70A484D8D412}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TranscriptTestRunner.Tests", "Libraries\TranscriptTestRunner.Tests\Microsoft.Bot.Builder.Testing.TestRunner.Tests.csproj", "{5CAE9F80-9BD3-480C-8504-552B31B265E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing.TestRunner.Tests", "Libraries\TranscriptTestRunner.Tests\Microsoft.Bot.Builder.Testing.TestRunner.Tests.csproj", "{5CAE9F80-9BD3-480C-8504-552B31B265E0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Functional", "Functional", "{DDEE53CF-F094-4009-B198-AA656CB7A009}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{9027483A-C2FD-48FF-922A-9050ED490B03}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests", "Tests\Integration\DotNet\IntegrationTests.csproj", "{BF885B2E-942C-43F3-BECA-64EFBB0598F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Tests.Integration", "Tests\Integration\DotNet\Microsoft.Bot.Builder.Tests.Integration.csproj", "{BF885B2E-942C-43F3-BECA-64EFBB0598F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbAttribute.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public class CosmosDbAttribute : Attribute

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseFixture.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Documents.Client;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     public abstract class CosmosDbBaseFixture : ConfigurationFixture, IAsyncLifetime
     {

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseTests.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     public class CosmosDbBaseTests
     {

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageFixture.cs
@@ -6,7 +6,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [CosmosDb(databaseId: "CosmosDbPartitionedStorageTests")]
     public class CosmosDbPartitionedStorageFixture : CosmosDbBaseFixture, IAsyncLifetime

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageTests.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Bot.Schema;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     public class CosmosDbPartitionedStorageTests : CosmosDbBaseTests, IClassFixture<CosmosDbPartitionedStorageFixture>
     {

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageFixture.cs
@@ -10,7 +10,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [CosmosDb(databaseId: "CosmosDbStorageTests")]
     public class CosmosDbStorageFixture : CosmosDbBaseFixture, IAsyncLifetime

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageTests.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [Trait("TestCategory", "Deprecated")]
     public class CosmosDbStorageTests : CosmosDbBaseTests, IClassFixture<CosmosDbStorageFixture>

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobStorageFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobStorageFixture.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Azure;
+using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    [Blobs(containerId: "AzureBlobStorageTests")]
+    public class AzureBlobStorageFixture : BlobsStorageBaseFixture, IAsyncLifetime
+    {
+        public IDictionary<StorageCase, IStorage> Storages { get; private set; }
+
+        public new async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+
+            Storages = new Dictionary<StorageCase, IStorage>
+            {
+                { StorageCase.Default, new AzureBlobStorage(storageAccount, ContainerId) },
+                { StorageCase.TypeNameHandlingNone, new AzureBlobStorage(storageAccount, ContainerId, new JsonSerializer() { TypeNameHandling = TypeNameHandling.None }) }
+            };
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobStorageTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobStorageTests.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    [Trait("TestCategory", "Deprecated")]
+    public class AzureBlobStorageTests : StorageBaseTests, IClassFixture<AzureBlobStorageFixture>
+    {
+        public AzureBlobStorageTests(AzureBlobStorageFixture azureBlobFixture)
+        {
+            UseStorages(azureBlobFixture.Storages);
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobTranscriptStoreFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobTranscriptStoreFixture.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Azure;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    [Blobs(containerId: "AzureBlobTranscriptStoreTests")]
+    public class AzureBlobTranscriptStoreFixture : BlobsStorageBaseFixture, IAsyncLifetime
+    {
+        public IDictionary<StorageCase, ITranscriptStore> Storages { get; private set; }
+
+        public new async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
+            Storages = new Dictionary<StorageCase, ITranscriptStore>
+            {
+                { StorageCase.Default, new AzureBlobTranscriptStore(ConnectionString, ContainerId) },
+            };
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobTranscriptStoreTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/AzureBlobTranscriptStoreTests.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    [Trait("TestCategory", "Deprecated")]
+    public class AzureBlobTranscriptStoreTests : BlobsTranscriptStoreBaseTests, IClassFixture<AzureBlobTranscriptStoreFixture>
+    {
+        public AzureBlobTranscriptStoreTests(ITestOutputHelper outputHandler, AzureBlobTranscriptStoreFixture blobFixture)
+            : base(outputHandler)
+        {
+            UseStorages(blobFixture.Storages);
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsAttribute.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public class BlobsAttribute : Attribute
+    {
+        public BlobsAttribute(string containerId = "BlobsContainer")
+        {
+            ContainerId = containerId;
+        }
+
+        public string ContainerId { get; private set; }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsStorageBaseFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsStorageBaseFixture.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    public class BlobsStorageBaseFixture : ConfigurationFixture, IAsyncLifetime
+    {
+        public BlobContainerClient Client { get; private set; }
+
+        public string ConnectionString { get; private set; }
+
+        public string ContainerId { get; private set; }
+
+        protected bool IsRunning { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            var attr = GetType().GetCustomAttribute(typeof(BlobsAttribute)) as BlobsAttribute;
+            ContainerId = attr?.ContainerId?.ToLower();
+
+            ConnectionString = Configuration["Azure:Storage:ConnectionString"];
+
+            Client = new BlobContainerClient(ConnectionString, ContainerId);
+
+            IsRunning = await IsServiceRunning();
+
+            await Client.CreateIfNotExistsAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (!IsRunning)
+            {
+                return;
+            }
+
+            await DeleteContainer();
+        }
+
+        protected async Task<bool> DeleteContainer()
+        {
+            try
+            {
+                using var cancellation = new CancellationTokenSource(Timeout);
+                await Client.DeleteIfExistsAsync(cancellationToken: cancellation.Token);
+                return true;
+            }
+            catch (TaskCanceledException ex)
+            {
+                const string message = "Storage: Error cleaning up 'Blobs' resources.";
+                throw new TaskCanceledException(message, ex);
+            }
+        }
+
+        protected async Task<bool> IsServiceRunning()
+        {
+            try
+            {
+                using var cancellation = new CancellationTokenSource(Timeout);
+                var client = CloudStorageAccount.Parse(ConnectionString).CreateCloudBlobClient();
+                await client.GetServicePropertiesAsync(cancellation.Token);
+                return true;
+            }
+            catch (TaskCanceledException ex)
+            {
+                const string message = "Storage: Unable to connect to the 'Blobs' endpoint.";
+                throw new TaskCanceledException(message, ex);
+            }
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsStorageFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsStorageFixture.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Azure.Blobs;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    [Blobs(containerId: "BlobsStorageTests")]
+    public class BlobsStorageFixture : BlobsStorageBaseFixture, IAsyncLifetime
+    {
+        public IDictionary<StorageCase, IStorage> Storages { get; private set; }
+
+        public new async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
+            Storages = new Dictionary<StorageCase, IStorage>
+            {
+                { StorageCase.Default, new BlobsStorage(ConnectionString, ContainerId) },
+                { StorageCase.TypeNameHandlingNone, new BlobsStorage(ConnectionString, ContainerId, new JsonSerializer() { TypeNameHandling = TypeNameHandling.None }) }
+            };
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsStorageTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsStorageTests.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    public class BlobsStorageTests : StorageBaseTests, IClassFixture<BlobsStorageFixture>
+    {
+        public BlobsStorageTests(BlobsStorageFixture blobFixture)
+        {
+            UseStorages(blobFixture.Storages);
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsTranscriptStoreBaseTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsTranscriptStoreBaseTests.cs
@@ -1,0 +1,478 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    public abstract class BlobsTranscriptStoreBaseTests
+    {
+        private readonly string testName;
+        private readonly string specialCharacters = "!@#$%^&*()~/\\><,.?';\"`~_}{][^";
+
+        public BlobsTranscriptStoreBaseTests(ITestOutputHelper outputHandler)
+        {
+            var testMember = outputHandler.GetType().GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+            var test = (ITest)testMember.GetValue(outputHandler);
+            testName = test.TestCase.TestMethod.Method.Name.ToLower();
+        }
+
+        public IDictionary<StorageCase, ITranscriptStore> Storages { get; private set; }
+
+        protected void UseStorages(IDictionary<StorageCase, ITranscriptStore> storages)
+        {
+            Storages = storages;
+        }
+
+        [Fact]
+        protected virtual async Task ListEmptyTranscripts()
+        {
+            var storage = Storages[StorageCase.Default];
+            var transcripts = await storage.ListTranscriptsAsync("unknown");
+
+            Assert.Empty(transcripts.Items);
+        }
+
+        [Fact]
+        protected virtual async Task ListEmptyActivities()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activities = await storage.GetTranscriptActivitiesAsync("unknown", "unknown");
+
+            Assert.Empty(activities.Items);
+        }
+
+        [Fact]
+        protected virtual async Task CreateActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activity = GetActivity();
+            await storage.LogActivityAsync(activity);
+
+            var page = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+            var activities = page.Items.Cast<Activity>().ToList();
+            var createdActivity = activities.FirstOrDefault();
+
+            Assert.Single(activities);
+            Assert.Equal(activity.Id, createdActivity.Id);
+            Assert.Equal(activity.Text, createdActivity.Text);
+            Assert.Equal(activity.Type, createdActivity.Type);
+        }
+
+        [Fact]
+        protected virtual async Task UpdateActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activity = GetActivity();
+            await storage.LogActivityAsync(activity);
+
+            var page = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+            var activities = page.Items.Cast<Activity>().ToList();
+            var createdActivity = activities.FirstOrDefault();
+
+            var activityToUpdate = CloneActivity(activity);
+            activityToUpdate.Type = ActivityTypes.MessageUpdate;
+            activityToUpdate.Text = "updated";
+            await storage.LogActivityAsync(activityToUpdate);
+
+            page = await storage.GetTranscriptActivitiesAsync(activityToUpdate.ChannelId, activityToUpdate.Conversation.Id);
+            var updatedActivities = page.Items.Cast<Activity>().ToList();
+            var updatedActivity = updatedActivities.FirstOrDefault();
+
+            Assert.Single(activities);
+            Assert.Equal(activity.Id, createdActivity.Id);
+            Assert.Equal(activity.Text, createdActivity.Text);
+            Assert.Equal(activity.Type, createdActivity.Type);
+
+            Assert.Single(updatedActivities);
+            Assert.Equal(createdActivity.Id, updatedActivity.Id);
+            Assert.NotEqual(createdActivity.Text, updatedActivity.Text);
+            Assert.Equal("updated", updatedActivity.Text);
+            Assert.Equal(ActivityTypes.Message, updatedActivity.Type);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activity = GetActivity();
+            await storage.LogActivityAsync(activity);
+
+            await storage.DeleteTranscriptAsync(activity.ChannelId, activity.Conversation.Id);
+            var page = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+            var activities = page.Items.Cast<Activity>().ToList();
+
+            Assert.Empty(activities);
+        }
+
+        [Fact]
+        protected virtual async Task TombstonedActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activity = GetActivity();
+            await storage.LogActivityAsync(activity);
+
+            var page = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+            var activities = page.Items.Cast<Activity>().ToList();
+            var createdActivity = activities.FirstOrDefault();
+
+            var activityToUpdate = CloneActivity(activity);
+            activityToUpdate.Type = ActivityTypes.MessageDelete;
+            await storage.LogActivityAsync(activityToUpdate);
+
+            page = await storage.GetTranscriptActivitiesAsync(activityToUpdate.ChannelId, activityToUpdate.Conversation.Id);
+            var updatedActivities = page.Items.Cast<Activity>().ToList();
+            var updatedActivity = updatedActivities.FirstOrDefault();
+
+            Assert.Single(updatedActivities);
+            Assert.Equal(createdActivity.Id, updatedActivity.Id);
+            Assert.Equal("deleted", updatedActivity.From.Id);
+            Assert.Equal(ActivityTypes.MessageDelete, updatedActivity.Type);
+        }
+
+        [Fact]
+        protected virtual async Task CreateActivityWithSpecialCharacters()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activity = GetActivity(id: specialCharacters, conversationId: specialCharacters);
+            await storage.LogActivityAsync(activity);
+
+            var page = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+            var activities = page.Items.Cast<Activity>().ToList();
+            var createdActivity = activities.FirstOrDefault();
+
+            Assert.Single(activities);
+            Assert.Equal(activity.Id, createdActivity.Id);
+            Assert.Equal(activity.Text, createdActivity.Text);
+            Assert.Equal(activity.Type, createdActivity.Type);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteActivityWithSpecialCharacters()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activity = GetActivity(id: specialCharacters, conversationId: specialCharacters);
+            await storage.LogActivityAsync(activity);
+
+            await storage.DeleteTranscriptAsync(activity.ChannelId, activity.Conversation.Id);
+            var page = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+            var activities = page.Items.Cast<Activity>().ToList();
+
+            Assert.Empty(activities);
+        }
+
+        [Fact]
+        protected virtual async Task CreateActivityWithPagedResult()
+        {
+            var storage = Storages[StorageCase.Default];
+            var activities = new List<Activity>();
+
+            for (var i = 0; i < 30; i++)
+            {
+                var act = GetActivity(id: i.ToString());
+                await storage.LogActivityAsync(act);
+                activities.Add(act);
+            }
+
+            var activity = activities.FirstOrDefault();
+
+            var page = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+            var nextPage = await storage.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id, page.ContinuationToken);
+
+            Assert.Equal(20, page.Items.Length);
+            Assert.NotNull(page.ContinuationToken);
+            Assert.True(page.ContinuationToken.Length > 0);
+            Assert.Equal(10, nextPage.Items.Length);
+            Assert.Null(nextPage.ContinuationToken);
+        }
+
+        [Fact]
+        protected virtual async Task TranscriptLoggerMiddleware_CreateActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversation = GetConversationReference();
+            var adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(storage));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                if (context.Activity.Text == "start")
+                {
+                    var typingActivity = new Activity
+                    {
+                        Type = ActivityTypes.Typing,
+                        RelatesTo = context.Activity.RelatesTo
+                    };
+                    await context.SendActivityAsync(typingActivity);
+                }
+                else
+                {
+                    await context.SendActivityAsync("echo:" + context.Activity.Text);
+                }
+            })
+            .Send("start")
+            .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+            .Delay(300)
+            .Send("hi")
+            .AssertReply("echo:hi")
+            .StartTestAsync();
+
+            var page = await GetPagedResultWithRetryAsync(
+                storage: storage,
+                conversation: conversation,
+                finishWhen: p => p.Items.Length == 4);
+            var activities = page.Items.Cast<Activity>().ToList();
+
+            Assert.Equal(4, activities.Count);
+            Assert.Equal("start", activities[0].Text);
+            Assert.Equal(ActivityTypes.Typing, activities[1].Type);
+            Assert.Equal("hi", activities[2].Text);
+            Assert.Equal("echo:hi", activities[3].Text);
+            foreach (var activity in activities)
+            {
+                Assert.True(!string.IsNullOrWhiteSpace(activity.Id));
+                Assert.True(activity.Timestamp > default(DateTimeOffset));
+            }
+        }
+
+        [Fact]
+        protected virtual async Task TranscriptLoggerMiddleware_UpdateActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversation = GetConversationReference();
+            var adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(storage));
+
+            Activity activityToUpdate = null;
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                if (context.Activity.Text == "update")
+                {
+                    activityToUpdate.Text = "updated";
+                    await context.UpdateActivityAsync(activityToUpdate);
+                }
+                else
+                {
+                    var activity = context.Activity.CreateReply("started");
+                    var response = await context.SendActivityAsync(activity);
+                    activity.Id = response.Id;
+                    activityToUpdate = CloneActivity(activity);
+                }
+            })
+            .Send("start")
+            .Delay(300)
+            .Send("update")
+            .AssertReply("updated")
+            .StartTestAsync();
+
+            var page = await GetPagedResultWithRetryAsync(
+                storage: storage,
+                conversation: conversation,
+                finishWhen: p => p.Items.Length == 3 && p.Items[1].AsMessageActivity().Text == "updated");
+            var activities = page.Items.Cast<Activity>().ToList();
+
+            Assert.Equal(3, activities.Count);
+            Assert.Equal("start", activities[0].Text);
+            Assert.Equal("updated", activities[1].Text);
+            Assert.Equal("update", activities[2].Text);
+        }
+
+        [Fact]
+        protected virtual async Task TranscriptLoggerMiddleware_UpdateActivityWithDate()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversation = GetConversationReference();
+            var adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(storage));
+            var startTime = new DateTimeOffset(DateTime.Now);
+
+            Activity activityToUpdate = null;
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                if (context.Activity.Text == "update")
+                {
+                    activityToUpdate.Text = "updated";
+                    await context.UpdateActivityAsync(activityToUpdate);
+                }
+                else
+                {
+                    var activity = context.Activity.CreateReply("started");
+                    var response = await context.SendActivityAsync(activity);
+                    activity.Id = response.Id;
+                    activityToUpdate = CloneActivity(activity);
+                }
+            })
+            .Send("start")
+            .Delay(300)
+            .Send("update")
+            .AssertReply("updated")
+            .StartTestAsync();
+
+            var page = await GetPagedResultWithRetryAsync(
+                storage: storage,
+                conversation: conversation,
+                startDate: startTime.DateTime,
+                finishWhen: p => p.Items.Length == 3 && p.Items[1].AsMessageActivity().Text == "updated");
+            var activities = page.Items.Cast<Activity>().ToList();
+
+            Assert.Equal(3, activities.Count);
+            Assert.Equal("start", activities[0].Text);
+            Assert.Equal("updated", activities[1].Text);
+            Assert.Equal("update", activities[2].Text);
+
+            startTime = new DateTimeOffset(DateTime.Now);
+            page = await storage.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, startDate: startTime);
+            Assert.Empty(page.Items);
+        }
+
+        [Fact]
+        protected virtual async Task TranscriptLoggerMiddleware_MissingUpdateActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversation = GetConversationReference();
+            var adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(storage));
+
+            var fooId = string.Empty;
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                fooId = context.Activity.Id;
+                var updateActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(context.Activity));
+                updateActivity.Text = "updated";
+                var response = await context.UpdateActivityAsync(updateActivity);
+            })
+            .Send("start")
+            .StartTestAsync();
+
+            var page = await GetPagedResultWithRetryAsync(
+                storage: storage,
+                conversation: conversation,
+                finishWhen: p => p.Items.Length == 2 && p.Items[1].AsMessageActivity().Text == "updated");
+            var activities = page.Items.Cast<Activity>().ToList();
+
+            Assert.Equal(2, activities.Count);
+            Assert.Equal(fooId, activities[0].Id);
+            Assert.Equal("start", activities[0].Text);
+            Assert.StartsWith("g_", activities[1].Id);
+            Assert.Equal("updated", activities[1].Text);
+        }
+
+        [Fact]
+        protected virtual async Task TranscriptLoggerMiddleware_DeleteActivity()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversation = GetConversationReference();
+            var adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(storage));
+            string activityId = null;
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                if (context.Activity.Text == "delete")
+                {
+                    await context.DeleteActivityAsync(activityId);
+                }
+                else
+                {
+                    var activity = context.Activity.CreateReply("started");
+                    var response = await context.SendActivityAsync(activity);
+                    activityId = response.Id;
+                }
+            })
+            .Send("start")
+            .AssertReply("started")
+            .Delay(300)
+            .Send("delete")
+            .StartTestAsync();
+
+            var page = await GetPagedResultWithRetryAsync(
+                storage: storage,
+                conversation: conversation,
+                finishWhen: p => p.Items.Length == 3 && p.Items[1].Type == ActivityTypes.MessageDelete);
+            var activities = page.Items.Cast<Activity>().ToList();
+
+            Assert.Equal(3, activities.Count);
+            Assert.Equal("start", activities[0].Text);
+            Assert.Equal(ActivityTypes.MessageDelete, activities[1].Type);
+            Assert.Equal("delete", activities[2].Text);
+        }
+
+        protected Activity CloneActivity(Activity activity)
+        {
+            return JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+        }
+
+        protected Activity GetActivity(string id = default, string channelId = default, string conversationId = default)
+        {
+            return new Activity
+            {
+                Id = $"activity-{id ?? testName}",
+                ChannelId = $"channel-{channelId ?? testName}",
+                Text = $"text-{testName}",
+                Type = ActivityTypes.Message,
+                Conversation = new ConversationAccount(id: $"conversation-{conversationId ?? testName}"),
+                Timestamp = DateTime.Now,
+                From = new ChannelAccount($"user-{testName}"),
+                Recipient = new ChannelAccount($"bot-{testName}"),
+            };
+        }
+
+        protected ConversationReference GetConversationReference(string channelId = default, string conversationId = default)
+        {
+            var conversation = $"conversation-{conversationId ?? testName}";
+            return new ConversationReference
+            {
+                ChannelId = $"channel-{channelId ?? testName}",
+                ServiceUrl = "https://test.com",
+                Conversation = new ConversationAccount(false, conversation, conversation),
+                User = new ChannelAccount($"user-{testName}"),
+                Bot = new ChannelAccount($"bot-{testName}"),
+                Locale = "en-us"
+            };
+        }
+
+        // NOTE: There are some async oddities within TranscriptLoggerMiddleware that make it difficult to set a short delay when running these tests that ensures
+        // the TestFlow completes while also logging transcripts. Some tests will not pass without longer delays, but this method minimizes the delay required.
+        protected async Task<PagedResult<IActivity>> GetPagedResultWithRetryAsync(ITranscriptStore storage, ConversationReference conversation, Func<PagedResult<IActivity>, bool> finishWhen, string continuationToken = null, DateTime startDate = default)
+        {
+            const int maxTimeout = 10000;
+            const int delay = 300;
+            PagedResult<IActivity> page = null;
+
+            for (var timeout = 0; timeout < maxTimeout; timeout += delay)
+            {
+                await Task.Delay(delay);
+                try
+                {
+                    page = await storage.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, continuationToken, startDate);
+                    if (finishWhen(page))
+                    {
+                        break;
+                    }
+                }
+                catch (KeyNotFoundException)
+                {
+                }
+                catch (NullReferenceException)
+                {
+                }
+            }
+
+            if (page == null)
+            {
+                throw new TimeoutException("Storage: Unable to retrieve the 'PagedResult' in time from the Blobs service.");
+            }
+
+            return page;
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsTranscriptStoreFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsTranscriptStoreFixture.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Azure.Blobs;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    [Blobs(containerId: "BlobsTranscriptStoreTests")]
+    public class BlobsTranscriptStoreFixture : BlobsStorageBaseFixture, IAsyncLifetime
+    {
+        public IDictionary<StorageCase, ITranscriptStore> Storages { get; private set; }
+
+        public new async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
+            Storages = new Dictionary<StorageCase, ITranscriptStore>
+            {
+                { StorageCase.Default, new BlobsTranscriptStore(ConnectionString, ContainerId) },
+            };
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsTranscriptStoreTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Blobs/BlobsTranscriptStoreTests.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Blobs
+{
+    public class BlobsTranscriptStoreTests : BlobsTranscriptStoreBaseTests, IClassFixture<BlobsTranscriptStoreFixture>
+    {
+        public BlobsTranscriptStoreTests(ITestOutputHelper outputHandler, BlobsTranscriptStoreFixture blobFixture)
+            : base(outputHandler)
+        {
+            UseStorages(blobFixture.Storages);
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/StorageBaseTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/StorageBaseTests.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage
+{
+    public abstract class StorageBaseTests
+    {
+        public StorageBaseTests()
+        {
+            Sample = new StorageItem() { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
+        }
+
+        public StorageItem Sample { get; private set; }
+
+        public IDictionary<StorageCase, IStorage> Storages { get; private set; }
+
+        protected void UseStorages(IDictionary<StorageCase, IStorage> storages)
+        {
+            Storages = storages;
+        }
+
+        [Fact]
+        protected virtual async Task ReadUnknownItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var result = await storage.ReadAsync(new[] { "unknown" });
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteUnknownItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            await storage.DeleteAsync(new[] { "unknown" });
+        }
+
+        [Fact]
+
+        protected virtual async Task CreateItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var dict = new Dictionary<string, object>
+            {
+                { "createItem", Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync<StorageItem>(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value;
+
+            Assert.Single(createdItems);
+            Assert.NotNull(created);
+            Assert.NotNull(created.ETag);
+            Assert.Equal(Sample.City, created.City);
+            Assert.Equal(Sample.MessageList, created.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task CreateItemWithSpecialCharacters()
+        {
+            var storage = Storages[StorageCase.Default];
+            const string key = "!@#$%^&*()~/\\><,.?';\"`~";
+            var dict = new Dictionary<string, object>
+            {
+                { key, Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync<StorageItem>(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value;
+
+            Assert.Single(createdItems);
+            Assert.NotNull(created);
+            Assert.NotNull(created.ETag);
+            Assert.Equal(Sample.City, created.City);
+            Assert.Equal(Sample.MessageList, created.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task UpdateItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var dict = new Dictionary<string, object>
+            {
+                { "updateItem", Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value as StorageItem;
+
+            // Update store item
+            created.MessageList = new string[] { "new message" };
+
+            await storage.WriteAsync(createdItems);
+
+            var updatedItems = await storage.ReadAsync(dict.Keys.ToArray());
+            var updated = updatedItems.FirstOrDefault().Value as StorageItem;
+
+            Assert.NotEqual(created.ETag, updated.ETag);
+            Assert.Single(updated.MessageList);
+            Assert.Equal(created.MessageList, updated.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var dict = new Dictionary<string, object>
+            {
+                { "deleteItem", Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync<StorageItem>(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value;
+
+            // Delete store item
+            await storage.DeleteAsync(dict.Keys.ToArray());
+
+            var deleted = await storage.ReadAsync(dict.Keys.ToArray());
+
+            Assert.NotNull(created);
+            Assert.Empty(deleted);
+        }
+
+        [Theory]
+        [InlineData(StorageCase.Default)]
+        [InlineData(StorageCase.TypeNameHandlingNone)]
+        protected virtual async Task CreateItemFromConversationState(StorageCase storageCase)
+        {
+            var storage = Storages[storageCase];
+            var conversationState = new ConversationState(storage);
+            var prop = conversationState.CreateProperty<StorageItem>(nameof(CreateItemFromConversationState));
+
+            var adapter = new TestAdapter();
+            var activity = adapter.MakeActivity();
+            activity.ChannelId = nameof(CreateItemFromConversationState);
+
+            // Created
+            var createdContext = new TurnContext(adapter, activity);
+            var created = await prop.GetAsync(createdContext, () => Sample);
+            await conversationState.SaveChangesAsync(createdContext, force: true);
+
+            // Read
+            var resultContext = new TurnContext(adapter, activity);
+            var result = await prop.GetAsync(resultContext);
+
+            Assert.NotNull(result);
+            Assert.Equal(created.City, result.City);
+            Assert.Equal(created.MessageList, result.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task UpdateItemFromConversationState()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversationState = new ConversationState(storage);
+            var prop = conversationState.CreateProperty<StorageItem>(nameof(UpdateItemFromConversationState));
+
+            var adapter = new TestAdapter();
+            var activity = adapter.MakeActivity();
+            activity.ChannelId = nameof(UpdateItemFromConversationState);
+
+            // Create
+            var createdContext = new TurnContext(adapter, activity);
+            var created = await prop.GetAsync(createdContext, () => Sample);
+            await conversationState.SaveChangesAsync(createdContext, force: true);
+
+            // Update
+            var updatedContext = new TurnContext(adapter, activity);
+            var updated = await prop.GetAsync(updatedContext);
+            updated.MessageList = new string[] { "new message" };
+            await conversationState.SaveChangesAsync(updatedContext, force: true);
+
+            // Read
+            var resultContext = new TurnContext(adapter, activity);
+            var result = await prop.GetAsync(resultContext);
+
+            Assert.NotNull(result);
+            Assert.NotEqual(created.MessageList, result.MessageList);
+            Assert.Equal(updated.MessageList, result.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteItemFromConversationState()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversationState = new ConversationState(storage);
+            var prop = conversationState.CreateProperty<StorageItem>(nameof(DeleteItemFromConversationState));
+
+            var adapter = new TestAdapter();
+            var activity = adapter.MakeActivity();
+            activity.ChannelId = nameof(DeleteItemFromConversationState);
+
+            // Create
+            var createdContext = new TurnContext(adapter, activity);
+            var created = await prop.GetAsync(createdContext, () => Sample);
+
+            // Delete
+            await prop.DeleteAsync(createdContext);
+            await conversationState.SaveChangesAsync(createdContext, force: true);
+
+            // Read
+            var resultContext = new TurnContext(adapter, activity);
+            var result = await prop.GetAsync(resultContext);
+
+            Assert.NotNull(created);
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(StorageCase.Default)]
+        [InlineData(StorageCase.TypeNameHandlingNone)]
+        protected virtual async Task StatePersistsThroughMultiTurn(StorageCase storageCase)
+        {
+            var storage = Storages[storageCase];
+            var userState = new UserState(storage);
+            var prop = userState.CreateProperty<StorageItem>("item");
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(userState));
+
+            var messageList = new string[] { "new message" };
+
+            await new TestFlow(
+                adapter,
+                async (context, cancellationToken) =>
+                {
+                    var state = await prop.GetAsync(context, () => Sample);
+                    Assert.NotNull(state);
+                    switch (context.Activity.Text)
+                    {
+                        case "set value":
+                            state.MessageList = messageList;
+                            await context.SendActivityAsync("value saved");
+                            break;
+                        case "get value":
+                            var message = string.Join(",", state.MessageList);
+                            await context.SendActivityAsync(message);
+                            break;
+                    }
+                })
+                .Test("set value", "value saved")
+                .Test("get value", string.Join(",", messageList))
+                .StartTestAsync();
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/StorageCase.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/StorageCase.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage
+{
+    public enum StorageCase
+    {
+        /// <summary>
+        /// Storage instance with default configuration.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Storage instance with JsonSerializer.TypeNameHandling equals to None configuration.
+        /// </summary>
+        TypeNameHandlingNone,
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/StorageItem.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/StorageItem.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Bot.Builder;
 using Newtonsoft.Json;
 
-namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage
 {
-    public class CosmosDbStorageItem : IStoreItem
+    public class StorageItem : IStoreItem
     {
         [JsonProperty(PropertyName = "messageList")]
         public string[] MessageList { get; set; }

--- a/Tests/Integration/DotNet/ConfigurationFixture.cs
+++ b/Tests/Integration/DotNet/ConfigurationFixture.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Extensions.Configuration;
 
-namespace IntegrationTests
+namespace Microsoft.Bot.Builder.Tests.Integration
 {
     public class ConfigurationFixture
     {
@@ -14,8 +15,12 @@ namespace IntegrationTests
                 .AddJsonFile("appsettings.Development.json", true, true)
                 .AddEnvironmentVariables()
                 .Build();
+
+            Timeout = TimeSpan.FromSeconds(3);
         }
 
         public IConfigurationRoot Configuration { get; private set; }
+
+        public TimeSpan Timeout { get; private set; }
     }
 }

--- a/Tests/Integration/DotNet/Microsoft.Bot.Builder.Tests.Integration.csproj
+++ b/Tests/Integration/DotNet/Microsoft.Bot.Builder.Tests.Integration.csproj
@@ -12,11 +12,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="$(BotBuilderVersion)" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="$(BotBuilderVersion)">
+      <NoWarn>NU1605</NoWarn>
+    </PackageReference>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="$(BotBuilderVersion)" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="$(BotBuilderVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="$(BotBuilderVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Queues" Version="$(BotBuilderVersionPreview)"/>
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="$(BotBuilderVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.22" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Integration/DotNet/appsettings.json
+++ b/Tests/Integration/DotNet/appsettings.json
@@ -5,6 +5,11 @@
       // See https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=ssl-netstd21#authenticate-requests for details on the well known key being used.
       "ServiceEndpoint": "https://localhost:8081",
       "AuthKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+    },
+    "Storage": {
+      // Connection string shortcut to connect to the local Storage Emulator.
+      // See https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string for details on how to configure the connection string.
+      "ConnectionString": "UseDevelopmentStorage=true"
     }
   }
 }


### PR DESCRIPTION
Addresses # 562

> **Note:** This PR depends on the commit 05e9916, that its already integrated on this branch.

## Description
This PR adds the `Azure Storage Blobs` tests to the new `Integration` test project.

### Detailed Changes
- Added `Microsoft.Bot.Builder.Azure.Blobs` dependency to the `Integration.csproj`.
 - The base tests have been renamed and marked as `Fact`, so, when other classes inherit from it, it will inject automatically all the tests for a specific `Storage`.
 - Added support for testing multiple `Storage` cases (e.g default config or with _TypeNameHandlingNone_ in the _JsonSerializer_).
- Added new `Blobs Storage` and `Azure Blob Storage` tests with similar tests and fixture configuration as for `CosmosDb`. Also, detects if the Blobs service is up and running.
- Added `AzureBlobTranscriptStoreFixture.cs` and `BlobsTranscriptStoreFixture.cs` fixtures for each type of tests and inherit from the `BlobsStorageBaseFixture.cs` base fixture.
- Added `BlobsTranscriptStoreBaseTests.cs` that contains all the base tests.
- Added `AzureBlobTranscriptStoreTests.cs` and `BlobsTranscriptStoreBaseTests.cs` test files that inherit the tests from the base class.

## Testing
The following images show the new Storage Blobs tests added to the Integration project, alongside the folder structure. 
![image](https://user-images.githubusercontent.com/62260472/153597639-3343c5c5-66fb-469a-80dd-e4fbfcfaccc9.png)
![image](https://user-images.githubusercontent.com/62260472/154340942-b72e3142-53cd-41c1-a458-e81572ebf98d.png)