### PR TITLE
Update Dockerfile endpoint to use Microsoft Container Registry (MCR)

### DIFF
--- a/Bots/JavaScript/Dockerfile
+++ b/Bots/JavaScript/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:lts-buster
+FROM mcr.microsoft.com/oryx/node:16
 
 # Set BotBuilder version env variable
 ARG BotBuilderVersion

--- a/Bots/JavaScript/EchoSkillBot-v3/Dockerfile
+++ b/Bots/JavaScript/EchoSkillBot-v3/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:lts-buster
+FROM mcr.microsoft.com/oryx/node:16
 
 # Set BotBuilder version env variable
 ARG BotBuilderVersion

--- a/Bots/Python/Dockerfile
+++ b/Bots/Python/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.8-buster
+FROM mcr.microsoft.com/oryx/python:3.10
 
 # Specify the bot folder.
 # When executing `docker build` remember to use the `--build-arg folder=./<bot-folder>`.


### PR DESCRIPTION
#minor

## Description
This PR updates the `Dockerfile` endpoint to use [Microsoft Container Registry (MCR)](https://github.com/microsoft/containerregistry).

### Detailed Changes
- Updated `Dockerfile` for JS, JSV3 and Python images from Docker to [Microsoft Container Registry (MCR)](https://github.com/microsoft/containerregistry).
  - JS: `node:lts-buster` => `node:16`
  - Python: `python:3.8-buster` => `python:3.10`

## Testing
The following image shows the change and the working Test Scenarios pipeline.
![image](https://user-images.githubusercontent.com/62260472/167444135-c87fde4e-ed96-4e15-85cb-14d20e811243.png)
